### PR TITLE
refactor: align REST path parameters and validation tags with gRPC naming

### DIFF
--- a/app/rest/bootstrap/router.go
+++ b/app/rest/bootstrap/router.go
@@ -59,7 +59,7 @@ func (r *Router) routerSetup(server *ServerHTTP) {
 
 	trxHandler := r.trxHandler
 	trx := e.Group("/transaction")
-	trxMerchant := trx.Group("/merchant/:id", validateToken, jwtMiddleware)
+	trxMerchant := trx.Group("/merchant/:merchant_id", validateToken, jwtMiddleware)
 	trxMerchant.GET("/omzet", trxHandler.MerchantOmzetGet)
 	trxOutlet := trx.Group("/outlet/:id", validateToken, jwtMiddleware)
 	trxOutlet.GET("/omzet", trxHandler.OutletOmzetGet)

--- a/app/rest/bootstrap/router.go
+++ b/app/rest/bootstrap/router.go
@@ -61,7 +61,7 @@ func (r *Router) routerSetup(server *ServerHTTP) {
 	trx := e.Group("/transaction")
 	trxMerchant := trx.Group("/merchant/:merchant_id", validateToken, jwtMiddleware)
 	trxMerchant.GET("/omzet", trxHandler.MerchantOmzetGet)
-	trxOutlet := trx.Group("/outlet/:id", validateToken, jwtMiddleware)
+	trxOutlet := trx.Group("/outlet/:outlet_id", validateToken, jwtMiddleware)
 	trxOutlet.GET("/omzet", trxHandler.OutletOmzetGet)
 
 	healthH := r.healthHandler

--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -1059,7 +1059,7 @@ const docTemplaterest = `{
                 }
             }
         },
-        "/transaction/outlet/{id}/omzet": {
+        "/transaction/outlet/{outlet_id}/omzet": {
             "get": {
                 "security": [
                     {
@@ -1081,7 +1081,7 @@ const docTemplaterest = `{
                     {
                         "type": "integer",
                         "description": "Outlet ID",
-                        "name": "id",
+                        "name": "outlet_id",
                         "in": "path",
                         "required": true
                     },

--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -908,7 +908,7 @@ const docTemplaterest = `{
                 }
             }
         },
-        "/transaction/merchant/{id}/omzet": {
+        "/transaction/merchant/{merchant_id}/omzet": {
             "get": {
                 "security": [
                     {
@@ -930,7 +930,7 @@ const docTemplaterest = `{
                     {
                         "type": "integer",
                         "description": "Merchant ID",
-                        "name": "id",
+                        "name": "merchant_id",
                         "in": "path",
                         "required": true
                     },

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -1048,7 +1048,7 @@
                 }
             }
         },
-        "/transaction/outlet/{id}/omzet": {
+        "/transaction/outlet/{outlet_id}/omzet": {
             "get": {
                 "security": [
                     {
@@ -1070,7 +1070,7 @@
                     {
                         "type": "integer",
                         "description": "Outlet ID",
-                        "name": "id",
+                        "name": "outlet_id",
                         "in": "path",
                         "required": true
                     },

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -897,7 +897,7 @@
                 }
             }
         },
-        "/transaction/merchant/{id}/omzet": {
+        "/transaction/merchant/{merchant_id}/omzet": {
             "get": {
                 "security": [
                     {
@@ -919,7 +919,7 @@
                     {
                         "type": "integer",
                         "description": "Merchant ID",
-                        "name": "id",
+                        "name": "merchant_id",
                         "in": "path",
                         "required": true
                     },

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -686,7 +686,7 @@ paths:
       summary: Token Refresh
       tags:
       - user
-  /transaction/merchant/{id}/omzet:
+  /transaction/merchant/{merchant_id}/omzet:
     get:
       consumes:
       - application/json
@@ -694,7 +694,7 @@ paths:
       parameters:
       - description: Merchant ID
         in: path
-        name: id
+        name: merchant_id
         required: true
         type: integer
       - enum:

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -779,7 +779,7 @@ paths:
       summary: Get Merchant Omzet
       tags:
       - transaction
-  /transaction/outlet/{id}/omzet:
+  /transaction/outlet/{outlet_id}/omzet:
     get:
       consumes:
       - application/json
@@ -787,7 +787,7 @@ paths:
       parameters:
       - description: Outlet ID
         in: path
-        name: id
+        name: outlet_id
         required: true
         type: integer
       - enum:

--- a/app/rest/handler/transaction/handler.go
+++ b/app/rest/handler/transaction/handler.go
@@ -45,13 +45,13 @@ func New(fw echoFW.IEcho, log *logCtx.Log, trxService trxService.IService, confi
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Param       id path int true "Merchant ID"
+// @Param       merchant_id path int true "Merchant ID"
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.MerchantOmzetGet true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=[]resTrxCore.MerchantOmzet}
 // @Failure     400 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
-// @Router		/transaction/merchant/{id}/omzet [get]
+// @Router		/transaction/merchant/{merchant_id}/omzet [get]
 func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewHTTP(echoCtx.Request().Context(), h.log, echoCtx.Request().RequestURI)
 	if err != nil {

--- a/app/rest/handler/transaction/handler.go
+++ b/app/rest/handler/transaction/handler.go
@@ -93,13 +93,13 @@ func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 // @Accept json
 // @Produce json
 // @Security BearerAuth
-// @Param       id path int true "Outlet ID"
+// @Param       outlet_id path int true "Outlet ID"
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.OutletOmzetGet true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=[]resTrxCore.OutletOmzet}
 // @Failure     400 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
-// @Router		/transaction/outlet/{id}/omzet [get]
+// @Router		/transaction/outlet/{outlet_id}/omzet [get]
 func (h *Handler) OutletOmzetGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewHTTP(echoCtx.Request().Context(), h.log, echoCtx.Request().RequestURI)
 	if err != nil {

--- a/core/transaction/request/merchant.pb.go
+++ b/core/transaction/request/merchant.pb.go
@@ -29,7 +29,7 @@ type MerchantOmzetGet struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	MerchantId    uint64  `protobuf:"varint,1,opt,name=merchant_id,json=merchantId,proto3" json:"-" param:"id" query:"-" validate:"required,min=1" example:"1"`          
+	MerchantId    uint64  `protobuf:"varint,1,opt,name=merchant_id,json=merchantId,proto3" json:"-" param:"merchant_id" query:"-" validate:"required,min=1" example:"1"`          
 	Mode          string  `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode" query:"mode" validate:"required,oneof=day month year" example:"day"`                                         
 	DatetimeStart string  `protobuf:"bytes,3,opt,name=datetime_start,json=datetimeStart,proto3" json:"datetime_start" query:"datetime_start" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"`  
 	DatetimeEnd   string  `protobuf:"bytes,4,opt,name=datetime_end,json=datetimeEnd,proto3" json:"datetime_end" query:"datetime_end" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"`        

--- a/core/transaction/request/merchant.proto
+++ b/core/transaction/request/merchant.proto
@@ -8,7 +8,7 @@ package request;
 option go_package = "github.com/dedyf5/resik/core/transaction/request";
 
 message MerchantOmzetGet {
-    uint64 merchant_id = 1; // @gotags: json:"-" param:"id" query:"-" validate:"required,min=1" example:"1"
+    uint64 merchant_id = 1; // @gotags: json:"-" param:"merchant_id" query:"-" validate:"required,min=1" example:"1"
     string mode = 2; // @gotags: json:"mode" query:"mode" validate:"required,oneof=day month year" example:"day"
     string datetime_start = 3; // @gotags: json:"datetime_start" query:"datetime_start" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"
     string datetime_end = 4; // @gotags: json:"datetime_end" query:"datetime_end" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"

--- a/core/transaction/request/outlet.pb.go
+++ b/core/transaction/request/outlet.pb.go
@@ -29,7 +29,7 @@ type OutletOmzetGet struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	OutletId      uint64  `protobuf:"varint,1,opt,name=outlet_id,json=outletId,proto3" json:"-" param:"id" query:"-" validate:"required,min=1" example:"1"`                
+	OutletId      uint64  `protobuf:"varint,1,opt,name=outlet_id,json=outletId,proto3" json:"-" param:"outlet_id" query:"-" validate:"required,min=1" example:"1"`                
 	Mode          string  `protobuf:"bytes,2,opt,name=mode,proto3" json:"mode" query:"mode" validate:"required,oneof=day month year" example:"day"`                                         
 	DatetimeStart string  `protobuf:"bytes,3,opt,name=datetime_start,json=datetimeStart,proto3" json:"datetime_start" query:"datetime_start" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"`  
 	DatetimeEnd   string  `protobuf:"bytes,4,opt,name=datetime_end,json=datetimeEnd,proto3" json:"datetime_end" query:"datetime_end" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"`        

--- a/core/transaction/request/outlet.proto
+++ b/core/transaction/request/outlet.proto
@@ -8,7 +8,7 @@ package request;
 option go_package = "github.com/dedyf5/resik/core/transaction/request";
 
 message OutletOmzetGet {
-    uint64 outlet_id = 1; // @gotags: json:"-" param:"id" query:"-" validate:"required,min=1" example:"1"
+    uint64 outlet_id = 1; // @gotags: json:"-" param:"outlet_id" query:"-" validate:"required,min=1" example:"1"
     string mode = 2; // @gotags: json:"mode" query:"mode" validate:"required,oneof=day month year" example:"day"
     string datetime_start = 3; // @gotags: json:"datetime_start" query:"datetime_start" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"
     string datetime_end = 4; // @gotags: json:"datetime_end" query:"datetime_end" validate:"required,datetime=2006-01-02 15:04:05" example:"2023-11-22 13:45:00"

--- a/utils/validator/validator.go
+++ b/utils/validator/validator.go
@@ -49,11 +49,24 @@ func New(langDefault language.Tag) *Validate {
 	}
 
 	validate.RegisterTagNameFunc(func(fld reflect.StructField) string {
-		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
-		if name == "-" {
-			return ""
+		jsonTag := fld.Tag.Get("json")
+
+		if jsonTag != "" && jsonTag != "-" {
+			for name := range strings.SplitSeq(jsonTag, ",") {
+				return name
+			}
 		}
-		return name
+
+		protoTag := fld.Tag.Get("protobuf")
+		if protoTag != "" {
+			for p := range strings.SplitSeq(protoTag, ",") {
+				if after, ok := strings.CutPrefix(p, "name="); ok {
+					return after
+				}
+			}
+		}
+
+		return fld.Name
 	})
 
 	for lang, translations := range transLang.Map {


### PR DESCRIPTION
## Summary
This PR synchronizes field naming between REST and gRPC interfaces to ensure a consistent developer experience. It updates path parameters and enhances the custom validator to prioritize protobuf tags.

## Key Changes

* **Path Parameters:** Renamed `{id}` to `{merchant_id}` and `{outlet_id}` in REST endpoints to match gRPC field definitions.
* **Validator Enhancement:** Updated `TagNameFunc` to support `protobuf` tags. This ensures that when `json:"-"` is used (common in gRPC-compatible structs), the validator correctly returns snake_case names (e.g., `merchant_id`) instead of PascalCase.
* **Performance:** Refactored tag parsing using `strings.SplitSeq` (Go 1.24+) for zero-allocation performance.

## Impact

* Consistent error messages across both protocols.
* Improved API clarity for clients using both REST and gRPC.