### PR TITLE
feat(logger): unify REST/gRPC logging standards and implement binary filtering

### DIFF
--- a/app/rest/fw/echo/middleware.go
+++ b/app/rest/fw/echo/middleware.go
@@ -5,7 +5,9 @@
 package echo
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -58,6 +60,17 @@ func LoggerAndResponseFormatterMiddleware(log *logCtx.Log, appModule config.Modu
 				return
 			}
 
+			var requestBody []byte
+			contentType := r.Header.Get("Content-Type")
+
+			if !strings.HasPrefix(contentType, "multipart/form-data") && r.Body != nil && r.Body != http.NoBody {
+				bodyBytes, err := io.ReadAll(r.Body)
+				if err == nil {
+					r.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+					requestBody = bodyBytes
+				}
+			}
+
 			correlationID := xid.New().String()
 			ctx := context.WithValue(
 				r.Context(),
@@ -72,7 +85,7 @@ func LoggerAndResponseFormatterMiddleware(log *logCtx.Log, appModule config.Modu
 
 			w.Header().Add(logCtx.CorrelationIDKeyXHeader.String(), correlationID)
 
-			lrw := logCtx.NewHTTP(w, appModule, log, time.Now(), r.Method, r.RequestURI, r.UserAgent())
+			lrw := logCtx.NewHTTP(w, appModule, log, time.Now(), r.Method, r.RequestURI, contentType, r.UserAgent(), requestBody)
 
 			r = r.WithContext(log.WithContext(ctx))
 

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -98,42 +99,75 @@ func (h *GRPC) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-// maskBinaryFields processes a struct (typically a gRPC request or response) and returns
-// a map representation where all binary fields ([]byte) are replaced with a descriptive
-// string indicating their size.
+// maskBinaryFields serves as a universal utility to sanitize data payloads for logging.
+// It recursively processes various data types (Structs, Maps, Slices, and Buffers)
+// to identify and mask binary data, ensuring logs remain concise and human-readable.
 //
-// It performs the following optimizations and features:
-//   - Field Name Prioritization: Resolves keys using "json" tag first, then "protobuf"
-//     name tag, and finally the struct field name.
-//   - Caching: Uses a global sync.Map to cache struct metadata (field indices, names,
-//     and types) to minimize reflection overhead on subsequent calls.
-//   - Memory Efficiency: Leverages Go 1.24+ iterators (strings.SplitSeq) for zero-allocation
-//     tag parsing during initial metadata discovery.
-//   - Safety: Gracefully handles pointers, nil values, and unexported fields to prevent
-//     runtime panics.
+// Key Features and Optimizations:
+//   - Multi-Protocol Support: Seamlessly handles gRPC structs (using reflection/tags)
+//     and REST payloads (unmarshaled maps or raw *bytes.Buffer).
+//   - Field Name Resolution: Prioritizes "json" tags, followed by "protobuf" name
+//     attributes, falling back to original struct field names for consistency.
+//   - Performance via Caching: Utilizes a global sync.Map to store struct metadata
+//     (field indices and tags), significantly reducing reflection overhead in high-throughput environments.
+//   - Smart Buffer Handling: Automatically attempts to unmarshal *bytes.Buffer
+//     if it contains JSON; otherwise, it masks the entire buffer as a binary label.
+//   - Recursive Sanitization: Deeply traverses nested maps, slices, and pointers
+//     to ensure all binary content is identified and masked.
 //
-// This is primarily used in logging interceptors to prevent large binary payloads
-// from bloating logs or causing performance degradation during JSON marshaling.
+// This utility is essential for logging interceptors/middleware to prevent
+// large binary payloads (e.g., file uploads, protobuf bytes) from causing
+// memory pressure or bloating log storage.
 func maskBinaryFields(data any) any {
 	if data == nil {
 		return nil
 	}
 
+	if buf, ok := data.(*bytes.Buffer); ok {
+		if buf == nil {
+			return nil
+		}
+		var rawData any
+		if err := json.Unmarshal(buf.Bytes(), &rawData); err == nil {
+			return maskBinaryFields(rawData)
+		}
+		return fmt.Sprintf("[BINARY: %d bytes]", buf.Len())
+	}
+
 	v := reflect.ValueOf(data)
-	if v.Kind() == reflect.Pointer {
+
+	for v.Kind() == reflect.Pointer {
 		if v.IsNil() {
-			return data
+			return nil
 		}
 		v = v.Elem()
 	}
 
-	if v.Kind() != reflect.Struct {
-		return data
+	switch v.Kind() {
+	case reflect.Struct:
+		return handleStructMasking(v)
+
+	case reflect.Map:
+		return handleMapMasking(v)
+
+	case reflect.Slice:
+		if v.Type().Elem().Kind() == reflect.Uint8 {
+			return fmt.Sprintf("[BINARY: %d bytes]", v.Len())
+		}
+		return handleSliceMasking(v)
+
+	default:
+		return v.Interface()
 	}
+}
 
+// handleStructMasking extracts and masks fields from a reflect.Value of kind Struct.
+// It leverages a metadata cache to maintain high performance and resolves field
+// names according to the framework's tag priority (JSON > Protobuf > FieldName).
+func handleStructMasking(v reflect.Value) any {
 	t := v.Type()
-
 	var infos []fieldInfo
+
 	if val, ok := fieldCache.Load(t); ok {
 		infos = val.([]fieldInfo)
 	} else {
@@ -174,17 +208,39 @@ func maskBinaryFields(data any) any {
 
 	m := make(map[string]any, len(infos))
 	for _, info := range infos {
-		valField := v.Field(info.index)
+		fieldVal := v.Field(info.index)
 		if info.isBinary {
-			if !valField.IsNil() {
-				m[info.name] = fmt.Sprintf("[BINARY: %d bytes]", valField.Len())
+			if !fieldVal.IsNil() {
+				m[info.name] = fmt.Sprintf("[BINARY: %d bytes]", fieldVal.Len())
 			} else {
 				m[info.name] = nil
 			}
 		} else {
-			m[info.name] = valField.Interface()
+			m[info.name] = maskBinaryFields(fieldVal.Interface())
 		}
 	}
-
 	return m
+}
+
+// handleMapMasking iterates through map keys and recursively applies masking
+// to their values. It is primarily used for processing REST request/response
+// payloads that have been unmarshaled into map[string]any.
+func handleMapMasking(v reflect.Value) any {
+	m := make(map[string]any, v.Len())
+	for _, key := range v.MapKeys() {
+		strKey := fmt.Sprintf("%v", key.Interface())
+		m[strKey] = maskBinaryFields(v.MapIndex(key).Interface())
+	}
+	return m
+}
+
+// handleSliceMasking processes slice or array elements. If the slice is a
+// byte slice ([]uint8), it returns a summary string. For other types,
+// it recursively processes each element to ensure nested binary data is masked.
+func handleSliceMasking(v reflect.Value) any {
+	s := make([]any, v.Len())
+	for i := 0; i < v.Len(); i++ {
+		s[i] = maskBinaryFields(v.Index(i).Interface())
+	}
+	return s
 }

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -6,7 +6,11 @@ package log
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"reflect"
+	"strings"
+	"sync"
 	"time"
 
 	configEntity "github.com/dedyf5/resik/entities/config"
@@ -24,6 +28,17 @@ type GRPC struct {
 	req       any
 	res       any
 }
+
+// fieldInfo stores pre-computed metadata for a single struct field.
+type fieldInfo struct {
+	index    int
+	name     string
+	isBinary bool
+}
+
+// fieldCache serves as a global registry for struct metadata to avoid
+// expensive reflection calls on every log entry.
+var fieldCache sync.Map
 
 func NewGRPC(appModule configEntity.Module, log *Log, start time.Time, uri string, req any, res any, err error) *GRPC {
 	status := &resPkg.Status{
@@ -58,17 +73,22 @@ func (h *GRPC) Write() {
 
 func (h *GRPC) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	grpc := h.status.GRPCStatus()
-	reqByte, _ := json.Marshal(h.req)
+
+	cleanReq := maskBinaryFields(h.req)
+	reqByte, _ := json.Marshal(cleanReq)
+
 	enc.AddString("app", h.appModule.DirectoryName())
 	enc.AddString(CorrelationIDKeyContext.String(), h.log.CorrelationID)
 	enc.AddString("path", h.uri)
 	enc.AddUint32("status_code", uint32(grpc.Code()))
 	enc.AddInt64("elapsed_micro", time.Since(h.start).Microseconds())
 	enc.AddString("req", string(reqByte))
+
 	if h.status.IsError() {
 		enc.AddString("res", h.status.MessageOrDefault())
 	} else {
-		resByte, _ := json.Marshal(h.res)
+		cleanRes := maskBinaryFields(h.res)
+		resByte, _ := json.Marshal(cleanRes)
 		resString := string(resByte)
 		if resString == "null" {
 			resString = ""
@@ -76,4 +96,95 @@ func (h *GRPC) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		enc.AddString("res", resString)
 	}
 	return nil
+}
+
+// maskBinaryFields processes a struct (typically a gRPC request or response) and returns
+// a map representation where all binary fields ([]byte) are replaced with a descriptive
+// string indicating their size.
+//
+// It performs the following optimizations and features:
+//   - Field Name Prioritization: Resolves keys using "json" tag first, then "protobuf"
+//     name tag, and finally the struct field name.
+//   - Caching: Uses a global sync.Map to cache struct metadata (field indices, names,
+//     and types) to minimize reflection overhead on subsequent calls.
+//   - Memory Efficiency: Leverages Go 1.24+ iterators (strings.SplitSeq) for zero-allocation
+//     tag parsing during initial metadata discovery.
+//   - Safety: Gracefully handles pointers, nil values, and unexported fields to prevent
+//     runtime panics.
+//
+// This is primarily used in logging interceptors to prevent large binary payloads
+// from bloating logs or causing performance degradation during JSON marshaling.
+func maskBinaryFields(data any) any {
+	if data == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(data)
+	if v.Kind() == reflect.Pointer {
+		if v.IsNil() {
+			return data
+		}
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return data
+	}
+
+	t := v.Type()
+
+	var infos []fieldInfo
+	if val, ok := fieldCache.Load(t); ok {
+		infos = val.([]fieldInfo)
+	} else {
+		infos = []fieldInfo{}
+		for i := 0; i < v.NumField(); i++ {
+			f := v.Field(i)
+			structField := t.Field(i)
+
+			if !f.CanInterface() {
+				continue
+			}
+
+			fieldName := structField.Name
+			if jsonTag := structField.Tag.Get("json"); jsonTag != "" && jsonTag != "-" {
+				parts := strings.Split(jsonTag, ",")
+				if parts[0] != "" {
+					fieldName = parts[0]
+				}
+			} else if protoTag := structField.Tag.Get("protobuf"); protoTag != "" {
+				for part := range strings.SplitSeq(protoTag, ",") {
+					if name, found := strings.CutPrefix(part, "name="); found {
+						fieldName = name
+						break
+					}
+				}
+			}
+
+			isBinary := f.Kind() == reflect.Slice && f.Type().Elem().Kind() == reflect.Uint8
+
+			infos = append(infos, fieldInfo{
+				index:    i,
+				name:     fieldName,
+				isBinary: isBinary,
+			})
+		}
+		fieldCache.Store(t, infos)
+	}
+
+	m := make(map[string]any, len(infos))
+	for _, info := range infos {
+		valField := v.Field(info.index)
+		if info.isBinary {
+			if !valField.IsNil() {
+				m[info.name] = fmt.Sprintf("[BINARY: %d bytes]", valField.Len())
+			} else {
+				m[info.name] = nil
+			}
+		} else {
+			m[info.name] = valField.Interface()
+		}
+	}
+
+	return m
 }

--- a/ctx/log/http.go
+++ b/ctx/log/http.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	configEntity "github.com/dedyf5/resik/entities/config"
@@ -19,19 +20,21 @@ import (
 
 type HTTP struct {
 	http.ResponseWriter
-	appModule  configEntity.Module
-	log        *Log
-	start      time.Time
-	statusCode int
-	method     string
-	uri        string
-	userAgent  string
-	body       *bytes.Buffer
+	appModule    configEntity.Module
+	log          *Log
+	start        time.Time
+	statusCode   int
+	method       string
+	uri          string
+	contentType  string
+	userAgent    string
+	requestBody  []byte
+	responseBody *bytes.Buffer
 }
 
-func NewHTTP(w http.ResponseWriter, appModule configEntity.Module, log *Log, start time.Time, method, uri, userAgent string) *HTTP {
+func NewHTTP(w http.ResponseWriter, appModule configEntity.Module, log *Log, start time.Time, method, uri, contentType, userAgent string, requestBody []byte) *HTTP {
 	var buf bytes.Buffer
-	return &HTTP{w, appModule, log, start, http.StatusOK, method, uri, userAgent, &buf}
+	return &HTTP{w, appModule, log, start, http.StatusOK, method, uri, contentType, userAgent, requestBody, &buf}
 }
 
 func (h *HTTP) WriteHeader(code int) {
@@ -45,7 +48,7 @@ func (h *HTTP) Write(buf []byte) (int, error) {
 	if err != nil {
 		panic(fmt.Sprintf("error encode new body response error: %s", err.Error()))
 	}
-	h.body.Write(bodyByte)
+	h.responseBody.Write(bodyByte)
 	h.writeLogger(loggerRes)
 	return h.ResponseWriter.Write(bodyByte)
 }
@@ -69,10 +72,37 @@ func (h *HTTP) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString(CorrelationIDKeyContext.String(), h.log.CorrelationID)
 	enc.AddString("method", h.method)
 	enc.AddString("path", h.uri)
+	enc.AddString("content_type", h.contentType)
 	enc.AddString("user_agent", h.userAgent)
 	enc.AddInt("status_code", h.statusCode)
 	enc.AddInt64("elapsed_micro", time.Since(h.start).Microseconds())
-	enc.AddString("response", h.body.String())
+
+	if strings.HasPrefix(h.contentType, "multipart/form-data") {
+		enc.AddString("req", "[MULTIPART: binary data omitted]")
+	} else {
+		var rawData any
+		if err := json.Unmarshal(h.requestBody, &rawData); err == nil {
+			cleanReq := maskBinaryFields(rawData)
+			reqByte, _ := json.Marshal(cleanReq)
+			enc.AddString("req", string(reqByte))
+		} else {
+			bodyStr := string(h.requestBody)
+			if len(bodyStr) > 1000 {
+				enc.AddString("req", bodyStr[:1000]+"[truncated]")
+			} else {
+				enc.AddString("req", bodyStr)
+			}
+		}
+	}
+
+	res := maskBinaryFields(h.responseBody)
+	switch v := res.(type) {
+	case string:
+		enc.AddString("res", v)
+	default:
+		enc.AddReflected("res", v)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
1. feat(logger): implement binary field masking and metadata caching for gRPC
    - Add maskBinaryFields utility
    - Implement metadata caching using sync.Map for performance
    - Prioritize field names from json and protobuf tags

2. feat(logger): implement REST request logging and universal binary filtering
    - Add request payload and content_type logging for REST middleware
    - Standardize response field name to res across REST and gRPC
    - Enhance maskBinaryFields to support *bytes.Buffer for response logging
    - Implement recursive masking for JSON maps and slices in REST