### PR TITLE
chore: implement golangci-lint and fix protobuf getter violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  enable:
+    - protogetter
+    - errchkjson
+    - errorlint
+    - perfsprint
+    - prealloc
+    - gosec
+    - testifylint
+    - bodyclose
+    - errcheck
+    - goconst
+    - gocritic
+    - govet
+    - ineffassign
+    - nilerr
+    - noctx
+    - staticcheck
+    - unconvert
+    - unused

--- a/app/grpc/handler/merchant/delete.go
+++ b/app/grpc/handler/merchant/delete.go
@@ -24,7 +24,7 @@ func (h *MerchantHandler) MerchantDelete(c context.Context, req *reqMerchantCore
 		return nil, err
 	}
 
-	if _, err = ctx.UserClaims().MerchantIDIsAccessible(req.Id); err != nil {
+	if _, err = ctx.UserClaims().MerchantIDIsAccessible(req.GetId()); err != nil {
 		return nil, err
 	}
 

--- a/app/grpc/handler/user/auth.go
+++ b/app/grpc/handler/user/auth.go
@@ -37,7 +37,7 @@ func (h *UserHandler) LoginPost(c context.Context, req *reqUserCore.LoginPost) (
 			Message: codes.OK.String(),
 		},
 		Data: &resUserCore.UserCredential{
-			Username: req.Username,
+			Username: req.GetUsername(),
 			Token:    token,
 		},
 	}, nil

--- a/app/grpc/proto/common/request.go
+++ b/app/grpc/proto/common/request.go
@@ -8,6 +8,6 @@ import commonEntity "github.com/dedyf5/resik/entities/common"
 
 func (r *Request) ToRequestEntity() commonEntity.Request {
 	return commonEntity.Request{
-		Lang: r.Lang,
+		Lang: r.GetLang(),
 	}
 }

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -205,7 +205,7 @@ func (h *Handler) MerchantDelete(echoCtx echo.Context) error {
 		return err
 	}
 
-	if _, err = ctx.UserClaims().MerchantIDIsAccessible(param.Id); err != nil {
+	if _, err = ctx.UserClaims().MerchantIDIsAccessible(param.GetId()); err != nil {
 		return err
 	}
 

--- a/app/rest/handler/user/handler.go
+++ b/app/rest/handler/user/handler.go
@@ -58,7 +58,7 @@ func (h *Handler) LoginPost(echoCtx echo.Context) error {
 		return err
 	}
 
-	token, err := h.userService.Auth(param.Auth{Ctx: ctx, Username: payload.Username, Password: payload.Password})
+	token, err := h.userService.Auth(param.Auth{Ctx: ctx, Username: payload.GetUsername(), Password: payload.GetPassword()})
 	if err != nil {
 		return err
 	}
@@ -66,7 +66,7 @@ func (h *Handler) LoginPost(echoCtx echo.Context) error {
 	return &resPkg.Status{
 		Code: http.StatusOK,
 		Data: resUserCore.UserCredential{
-			Username: payload.Username,
+			Username: payload.GetUsername(),
 			Token:    token,
 		},
 	}

--- a/core/merchant/request/delete.go
+++ b/core/merchant/request/delete.go
@@ -8,6 +8,6 @@ import "github.com/dedyf5/resik/entities/merchant"
 
 func (m *MerchantDelete) ToMerchant() *merchant.Merchant {
 	return &merchant.Merchant{
-		ID: m.Id,
+		ID: m.GetId(),
 	}
 }

--- a/core/merchant/request/list.go
+++ b/core/merchant/request/list.go
@@ -13,21 +13,21 @@ import (
 func (m *MerchantListGet) ToParam(c *ctx.Ctx) *paramMerchant.MerchantListGet {
 	orderStr := "name"
 	if m.Order != nil {
-		orderStr = *m.Order
+		orderStr = m.GetOrder()
 	}
 	var page int = 1
 	if m.Page != nil {
-		page = int(*m.Page)
+		page = int(m.GetPage())
 	}
 	var limit int = 10
 	if m.Limit != nil {
-		limit = int(*m.Limit)
+		limit = int(m.GetLimit())
 	}
 	return &paramMerchant.MerchantListGet{
 		Ctx:         c,
 		MerchantIDs: c.UserClaims().MerchantIDs,
 		Filter: goku.Filter{
-			Search: m.Search,
+			Search: m.GetSearch(),
 			Page:   page,
 			Limit:  limit,
 		},

--- a/core/merchant/request/upsert.go
+++ b/core/merchant/request/upsert.go
@@ -12,14 +12,14 @@ import (
 )
 
 func (m *MerchantPost) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, status *resPkg.Status) {
-	datetime, err := datetime.FromString(m.CreatedAt, datetime.FormatyyyyMMddHHmmss)
+	datetime, err := datetime.FromString(m.GetCreatedAt(), datetime.FormatyyyyMMddHHmmss)
 	if err != nil {
 		return nil, err
 	}
 	userID := ctx.UserClaims().UserID
 	return &merchantEntity.Merchant{
 		UserID:    userID,
-		Name:      m.Name,
+		Name:      m.GetName(),
 		CreatedBy: userID,
 		CreatedAt: *datetime,
 		UpdatedBy: userID,
@@ -28,13 +28,13 @@ func (m *MerchantPost) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, sta
 }
 
 func (m *MerchantPut) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, status *resPkg.Status) {
-	datetime, err := datetime.FromString(m.UpdatedAt, datetime.FormatyyyyMMddHHmmss)
+	datetime, err := datetime.FromString(m.GetUpdatedAt(), datetime.FormatyyyyMMddHHmmss)
 	if err != nil {
 		return nil, err
 	}
 	return &merchantEntity.Merchant{
-		ID:        m.Id,
-		Name:      m.Name,
+		ID:        m.GetId(),
+		Name:      m.GetName(),
 		UpdatedBy: ctx.UserClaims().UserID,
 		UpdatedAt: *datetime,
 	}, nil

--- a/core/transaction/request/merchant.go
+++ b/core/transaction/request/merchant.go
@@ -14,26 +14,26 @@ import (
 func (m *MerchantOmzetGet) ToParam(c *ctx.Ctx) *trxParam.MerchantOmzetGet {
 	orderStr := "period"
 	if m.Order != nil {
-		orderStr = *m.Order
+		orderStr = m.GetOrder()
 	}
 	var page int = 1
 	if m.Page != nil {
-		page = int(*m.Page)
+		page = int(m.GetPage())
 	}
 	var limit int = 10
 	if m.Limit != nil {
-		limit = int(*m.Limit)
+		limit = int(m.GetLimit())
 	}
 	return &trxParam.MerchantOmzetGet{
 		Ctx:        c,
-		MerchantID: m.MerchantId,
+		MerchantID: m.GetMerchantId(),
 		GroupPeriod: groupperiod.GroupPeriod{
-			Mode:          groupperiod.Mode(m.Mode),
-			DatetimeStart: m.DatetimeStart,
-			DatetimeEnd:   m.DatetimeEnd,
+			Mode:          groupperiod.Mode(m.GetMode()),
+			DatetimeStart: m.GetDatetimeStart(),
+			DatetimeEnd:   m.GetDatetimeEnd(),
 		},
 		Filter: goku.Filter{
-			Search: m.Search,
+			Search: m.GetSearch(),
 			Page:   page,
 			Limit:  limit,
 		},

--- a/core/transaction/request/outlet.go
+++ b/core/transaction/request/outlet.go
@@ -14,26 +14,26 @@ import (
 func (o *OutletOmzetGet) ToParam(c *ctx.Ctx) *trxParam.OutletOmzetGet {
 	orderStr := "period"
 	if o.Order != nil {
-		orderStr = *o.Order
+		orderStr = o.GetOrder()
 	}
 	var page int = 1
 	if o.Page != nil {
-		page = int(*o.Page)
+		page = int(o.GetPage())
 	}
 	var limit int = 10
 	if o.Limit != nil {
-		limit = int(*o.Limit)
+		limit = int(o.GetLimit())
 	}
 	return &trxParam.OutletOmzetGet{
 		Ctx:      c,
-		OutletID: o.OutletId,
+		OutletID: o.GetOutletId(),
 		GroupPeriod: groupperiod.GroupPeriod{
-			Mode:          groupperiod.Mode(o.Mode),
-			DatetimeStart: o.DatetimeStart,
-			DatetimeEnd:   o.DatetimeEnd,
+			Mode:          groupperiod.Mode(o.GetMode()),
+			DatetimeStart: o.GetDatetimeStart(),
+			DatetimeEnd:   o.GetDatetimeEnd(),
 		},
 		Filter: goku.Filter{
-			Search: o.Search,
+			Search: o.GetSearch(),
 			Page:   page,
 			Limit:  limit,
 		},

--- a/core/user/request/auth.go
+++ b/core/user/request/auth.go
@@ -12,7 +12,7 @@ import (
 func (l *LoginPost) ToParam(c *ctx.Ctx) userParam.Auth {
 	return userParam.Auth{
 		Ctx:      c,
-		Username: l.Username,
-		Password: l.Password,
+		Username: l.GetUsername(),
+		Password: l.GetPassword(),
 	}
 }


### PR DESCRIPTION
- chore: add golangci-lint configuration
- fix(proto): migrate direct field access to getters
Replaced direct access to Protobuf struct fields with their corresponding
Getter methods to avoid potential nil pointer dereferences and satisfy
the protogetter linter rules.