### PR TITLE
fix(log): extract dynamic message from gRPC response status

### DIFF
--- a/app/grpc/proto/status/status.go
+++ b/app/grpc/proto/status/status.go
@@ -10,6 +10,25 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+type statusGetter interface {
+	GetStatus() *Status
+}
+
+// Extract pulls the Status message from an arbitrary object, typically a gRPC response.
+//
+// Returns nil if the object is nil, or if it does not satisfy the status getter interface.
+func Extract(param any) *Status {
+	if param == nil {
+		return nil
+	}
+
+	if s, ok := param.(statusGetter); ok {
+		return s.GetStatus()
+	}
+
+	return nil
+}
+
 func CodePlus(code codes.Code) string {
 	return fmt.Sprintf("%d.1", code)
 }

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	statusProto "github.com/dedyf5/resik/app/grpc/proto/status"
 	configEntity "github.com/dedyf5/resik/entities/config"
 	resPkg "github.com/dedyf5/resik/pkg/response"
 	"go.uber.org/zap"
@@ -49,12 +50,18 @@ func NewGRPC(appModule configEntity.Module, log *Log, start time.Time, path stri
 	status := &resPkg.Status{
 		Code: http.StatusOK,
 	}
+
+	if s := statusProto.Extract(responseBody); s != nil {
+		status.Message = s.GetMessage()
+	}
+
 	if err != nil {
 		switch ty := err.(type) {
 		case *resPkg.Status:
 			status = ty
 		}
 	}
+
 	return &GRPC{
 		appModule:    appModule,
 		log:          log,


### PR DESCRIPTION
Replaces the static OK message in gRPC logs with the actual message from the response status. This ensures that successful logs reflect the specific status message returned by the API.