### PR TITLE
refactor: unify app lifecycle and context propagation

### DIFF
--- a/app/grpc/bootstrap/app.go
+++ b/app/grpc/bootstrap/app.go
@@ -7,10 +7,7 @@ package bootstrap
 import (
 	"context"
 	"log"
-	"os"
-	"os/signal"
 	"runtime"
-	"syscall"
 )
 
 type App struct {
@@ -26,28 +23,12 @@ func newApp(serverHTTP *ServerHTTP) (*App, func(), error) {
 	}, nil
 }
 
-func (app *App) Start() {
+func (app *App) Start(c context.Context) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	terminalHandler := make(chan os.Signal, 1)
-	signal.Notify(
-		terminalHandler,
-		os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-
-	go func() {
-		in := <-terminalHandler
-		log.Printf("SYSTEM CALL: %+v", in)
-		cancel()
-	}()
 
 	app.serverHTTP.Start()
 
-	<-ctx.Done()
+	<-c.Done()
+
+	log.Println("received shutdown signal, stopping application...")
 }

--- a/app/grpc/bootstrap/server.go
+++ b/app/grpc/bootstrap/server.go
@@ -5,6 +5,7 @@
 package bootstrap
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -24,8 +25,9 @@ type ServerHTTP struct {
 	interceptor *middleware.Interceptor
 }
 
-func newServerHTTP(config config.Config, router *Router, interceptor *middleware.Interceptor) *ServerHTTP {
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", config.App.Port))
+func newServerHTTP(c context.Context, config config.Config, router *Router, interceptor *middleware.Interceptor) *ServerHTTP {
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(c, "tcp", fmt.Sprintf(":%d", config.App.Port))
 	if err != nil {
 		log.Fatalf("HTTP SERVER LISTEN ERROR: %s", err.Error())
 		return nil

--- a/app/grpc/bootstrap/wire.go
+++ b/app/grpc/bootstrap/wire.go
@@ -8,6 +8,8 @@
 package bootstrap
 
 import (
+	"context"
+
 	generalHandler "github.com/dedyf5/resik/app/grpc/handler/general"
 	healthHandler "github.com/dedyf5/resik/app/grpc/handler/health"
 	merchantHandler "github.com/dedyf5/resik/app/grpc/handler/merchant"
@@ -105,7 +107,7 @@ func provideHasherConfig(conf configEntity.Auth) *pkgHash.Argon2Config {
 	}
 }
 
-func InitializeHTTP() (*App, func(), error) {
+func InitializeHTTP(c context.Context) (*App, func(), error) {
 	wire.Build(
 		configGeneralSet,
 		utilSet,

--- a/app/grpc/bootstrap/wire_gen.go
+++ b/app/grpc/bootstrap/wire_gen.go
@@ -7,6 +7,7 @@
 package bootstrap
 
 import (
+	"context"
 	"github.com/dedyf5/resik/app/grpc/handler/general"
 	"github.com/dedyf5/resik/app/grpc/handler/health"
 	merchant2 "github.com/dedyf5/resik/app/grpc/handler/merchant"
@@ -37,7 +38,7 @@ import (
 
 // Injectors from wire.go:
 
-func InitializeHTTP() (*App, func(), error) {
+func InitializeHTTP(c context.Context) (*App, func(), error) {
 	config := _wireConfigValue
 	configLog := config.Log
 	app := config.App
@@ -76,7 +77,7 @@ func InitializeHTTP() (*App, func(), error) {
 	healthHandler := health.New(iService)
 	router := newRouter(config, generalHandler, merchantHandler, transactionHandler, userHandler, healthHandler)
 	interceptor := middleware.NewInterceptor(app, auth, logLog)
-	serverHTTP := newServerHTTP(config, router, interceptor)
+	serverHTTP := newServerHTTP(c, config, router, interceptor)
 	bootstrapApp, cleanup3, err := newApp(serverHTTP)
 	if err != nil {
 		cleanup2()

--- a/app/grpc/main.go
+++ b/app/grpc/main.go
@@ -4,14 +4,24 @@
 
 package grpc
 
-import "github.com/dedyf5/resik/app/grpc/bootstrap"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dedyf5/resik/app/grpc/bootstrap"
+)
 
 var app *bootstrap.App
 var cleanup func()
 var err error
 
 func Run() {
-	app, cleanup, err = bootstrap.InitializeHTTP()
+	c, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	app, cleanup, err = bootstrap.InitializeHTTP(c)
 
 	if err != nil {
 		panic(err)
@@ -21,6 +31,7 @@ func Run() {
 		panic("Failed to initialize app")
 	}
 
-	app.Start()
+	app.Start(c)
+
 	defer cleanup()
 }

--- a/app/rest/bootstrap/app.go
+++ b/app/rest/bootstrap/app.go
@@ -7,10 +7,7 @@ package bootstrap
 import (
 	"context"
 	"log"
-	"os"
-	"os/signal"
 	"runtime"
-	"syscall"
 )
 
 type App struct {
@@ -33,29 +30,13 @@ func newApp(
 	}, nil
 }
 
-func (app *App) Start() {
+func (app *App) Start(c context.Context) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	terminalHandler := make(chan os.Signal, 1)
-	signal.Notify(
-		terminalHandler,
-		os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGTERM,
-		syscall.SIGQUIT,
-	)
-
-	go func() {
-		in := <-terminalHandler
-		log.Printf("SYSTEM CALL: %+v", in)
-		cancel()
-	}()
-
 	app.router.routerSetup(app.serverHTTP)
-	app.serverHTTP.Start()
+	app.serverHTTP.Start(c)
 
-	<-ctx.Done()
+	<-c.Done()
+
+	log.Println("received shutdown signal, stopping application...")
 }

--- a/app/rest/bootstrap/server.go
+++ b/app/rest/bootstrap/server.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"time"
 
@@ -46,20 +47,26 @@ func newServerHTTP(config config.Config, log *logCtx.Log) *ServerHTTP {
 	}
 }
 
-func (s *ServerHTTP) Start() {
+func (s *ServerHTTP) Start(c context.Context) {
 	addr := s.config.App.HostPort()
 	appName := color.Format(color.GREEN, s.config.App.Name)
 	version := color.Format(color.YELLOW, s.config.App.Version)
 	fmt.Printf("%s%s version %s\n\n", config.AppLogoASCII, appName, version)
 	log.Printf("STARTED HTTP SERVER AT %v\n", addr)
+
 	go func() {
-		err := s.echo.StartServer(&http.Server{
+		server := &http.Server{
 			Addr:              addr,
 			ReadHeaderTimeout: s.config.HTTP.ReadHeaderTimeout,
 			ReadTimeout:       s.config.HTTP.ReadTimeout,
 			WriteTimeout:      s.config.HTTP.WriteTimeout,
 			IdleTimeout:       s.config.HTTP.IdleTimeout,
-		})
+			BaseContext: func(_ net.Listener) context.Context {
+				return c
+			},
+		}
+
+		err := s.echo.StartServer(server)
 		if err != nil {
 			if errors.Is(err, http.ErrServerClosed) {
 				log.Println("HTTP SERVER CLOSED")

--- a/app/rest/bootstrap/wire.go
+++ b/app/rest/bootstrap/wire.go
@@ -8,6 +8,8 @@
 package bootstrap
 
 import (
+	"context"
+
 	fw "github.com/dedyf5/resik/app/rest/fw/echo"
 	generalHandler "github.com/dedyf5/resik/app/rest/handler/general"
 	healthHandler "github.com/dedyf5/resik/app/rest/handler/health"
@@ -107,7 +109,7 @@ func provideHasherConfig(conf configEntity.Auth) *pkgHash.Argon2Config {
 	}
 }
 
-func InitializeHTTP() (*App, func(), error) {
+func InitializeHTTP(c context.Context) (*App, func(), error) {
 	wire.Build(
 		configGeneralSet,
 		utilSet,

--- a/app/rest/bootstrap/wire_gen.go
+++ b/app/rest/bootstrap/wire_gen.go
@@ -7,6 +7,7 @@
 package bootstrap
 
 import (
+	"context"
 	"github.com/dedyf5/resik/app/rest/fw/echo"
 	"github.com/dedyf5/resik/app/rest/handler/general"
 	"github.com/dedyf5/resik/app/rest/handler/health"
@@ -37,7 +38,7 @@ import (
 
 // Injectors from wire.go:
 
-func InitializeHTTP() (*App, func(), error) {
+func InitializeHTTP(c context.Context) (*App, func(), error) {
 	config := _wireConfigValue
 	configLog := config.Log
 	app := config.App

--- a/app/rest/main.go
+++ b/app/rest/main.go
@@ -4,7 +4,14 @@
 
 package rest
 
-import "github.com/dedyf5/resik/app/rest/bootstrap"
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/dedyf5/resik/app/rest/bootstrap"
+)
 
 var app *bootstrap.App
 var cleanup func()
@@ -14,7 +21,10 @@ var err error
 // @in header
 // @name Authorization
 func Run() {
-	app, cleanup, err = bootstrap.InitializeHTTP()
+	c, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	app, cleanup, err = bootstrap.InitializeHTTP(c)
 
 	if err != nil {
 		panic(err)
@@ -24,6 +34,7 @@ func Run() {
 		panic("Failed to initialize app")
 	}
 
-	app.Start()
+	app.Start(c)
+
 	defer cleanup()
 }


### PR DESCRIPTION
Unified the application lifecycle by passing the main context down to the transport layer. Implemented BaseContext for REST to ensure request-level awareness of app shutdown.