### PR TITLE
refactor: use safe integer casting in meta setup

### DIFF
--- a/app/grpc/handler/merchant/list.go
+++ b/app/grpc/handler/merchant/list.go
@@ -38,12 +38,17 @@ func (h *MerchantHandler) MerchantListGet(c context.Context, req *reqMerchantCor
 		code = codes.NotFound
 	}
 
+	metaRes, err := meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MerchantListGetRes{
 		Status: &status.Status{
 			Code:    status.CodePlus(code),
 			Message: code.String(),
 		},
 		Data: response.MerchantListFromEntity(res.Data),
-		Meta: meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page),
+		Meta: metaRes,
 	}, nil
 }

--- a/app/grpc/handler/transaction/merchant.go
+++ b/app/grpc/handler/transaction/merchant.go
@@ -37,12 +37,17 @@ func (h *TransactionHandler) MerchantOmzetGet(c context.Context, req *reqTrxCore
 		return nil, err
 	}
 
+	metaRes, err := meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MerchantOmzetGetRes{
 		Status: &status.Status{
 			Code:    status.CodePlus(codes.OK),
 			Message: codes.OK.String(),
 		},
 		Data: resTrxCore.MerchantOmzetFromEntity(res.Data),
-		Meta: meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page),
+		Meta: metaRes,
 	}, nil
 }

--- a/app/grpc/handler/transaction/outlet.go
+++ b/app/grpc/handler/transaction/outlet.go
@@ -37,12 +37,17 @@ func (h *TransactionHandler) OutletOmzetGet(c context.Context, req *reqTrxCore.O
 		return nil, err
 	}
 
+	metaRes, err := meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page)
+	if err != nil {
+		return nil, err
+	}
+
 	return &OutletOmzetGetRes{
 		Status: &status.Status{
 			Code:    status.CodePlus(codes.OK),
 			Message: codes.OK.String(),
 		},
 		Data: resTrxCore.OutletOmzetFromEntity(res.Data),
-		Meta: meta.MetaSetup(res.Total, param.Filter.Limit, param.Filter.Page),
+		Meta: metaRes,
 	}, nil
 }

--- a/app/grpc/proto/meta/meta.go
+++ b/app/grpc/proto/meta/meta.go
@@ -4,33 +4,67 @@
 
 package meta
 
-import httpUtil "github.com/dedyf5/resik/utils/http"
+import (
+	resPkg "github.com/dedyf5/resik/pkg/response"
+	httpUtil "github.com/dedyf5/resik/utils/http"
+	numUtil "github.com/dedyf5/resik/utils/numbers"
+)
 
-func MetaSetup(total uint64, limit, currentPage int) *Meta {
-	return &Meta{
-		Total: total,
-		Limit: int32(limit),
-		Page:  MetaPageSetup(total, limit, currentPage),
+func MetaSetup(total uint64, limit, currentPage int) (meta *Meta, err *resPkg.Status) {
+	limitRes, err := numUtil.SafeConvert[int32](limit)
+	if err != nil {
+		return nil, err
 	}
+
+	pageRes, err := MetaPageSetup(total, limit, currentPage)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Meta{Total: total, Limit: limitRes, Page: pageRes}, nil
 }
 
-func MetaPageSetup(total uint64, limit, currentPage int) *MetaPage {
+func MetaPageSetup(total uint64, limit, currentPage int) (metaPage *MetaPage, err *resPkg.Status) {
 	page := httpUtil.Page(total, limit, currentPage)
+
+	first, err := numUtil.SafeConvert[int32](page.First)
+	if err != nil {
+		return nil, err
+	}
+
 	var previous *int32 = nil
 	if page.Previous != nil {
-		tmp := int32(*page.Previous)
-		previous = &tmp
+		prevRes, err := numUtil.SafeConvert[int32](*page.Previous)
+		if err != nil {
+			return nil, err
+		}
+		previous = &prevRes
 	}
+
+	current, err := numUtil.SafeConvert[int32](page.Current)
+	if err != nil {
+		return nil, err
+	}
+
 	var next *int32 = nil
 	if page.Next != nil {
-		tmp := int32(*page.Next)
-		next = &tmp
+		nextRes, err := numUtil.SafeConvert[int32](*page.Next)
+		if err != nil {
+			return nil, err
+		}
+		next = &nextRes
 	}
+
+	last, err := numUtil.SafeConvert[int32](page.Last)
+	if err != nil {
+		return nil, err
+	}
+
 	return &MetaPage{
-		First:    int32(page.First),
+		First:    first,
 		Previous: previous,
-		Current:  int32(page.Current),
+		Current:  current,
 		Next:     next,
-		Last:     int32(page.Last),
-	}
+		Last:     last,
+	}, nil
 }

--- a/pkg/numbers/integer.go
+++ b/pkg/numbers/integer.go
@@ -1,0 +1,43 @@
+// Resik
+// Author: Dedy Fajar Setyawan
+// See: https://github.com/dedyf5/resik
+
+package numbers
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Integer defines a type constraint for all signed and unsigned integer types.
+type Integer interface {
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 | ~uintptr
+}
+
+type Target Integer
+type Source Integer
+
+var (
+	// ErrOverflow is returned when the value exceeds the capacity of the target type.
+	ErrOverflow = errors.New("integer overflow: value exceeds target type capacity")
+
+	// ErrSignMismatch is returned when converting a negative value to an unsigned type.
+	ErrSignMismatch = errors.New("sign mismatch: cannot convert negative value to unsigned type")
+)
+
+// SafeConvert performs a bounds-checked conversion between any two integer types.
+// It returns an error if the conversion would result in data loss or sign mismatch.
+func SafeConvert[T Target, S Source](val S) (T, error) {
+	result := T(val)
+
+	if S(result) != val {
+		return 0, fmt.Errorf("%w: value %v does not fit in %T", ErrOverflow, val, result)
+	}
+
+	if val < 0 && result > 0 {
+		return 0, fmt.Errorf("%w: value %v to %T", ErrSignMismatch, val, result)
+	}
+
+	return result, nil
+}

--- a/utils/numbers/integer.go
+++ b/utils/numbers/integer.go
@@ -1,0 +1,23 @@
+// Resik
+// Author: Dedy Fajar Setyawan
+// See: https://github.com/dedyf5/resik
+
+package numbers
+
+import (
+	"net/http"
+
+	"github.com/dedyf5/resik/pkg/numbers"
+	resPkg "github.com/dedyf5/resik/pkg/response"
+)
+
+func SafeConvert[T numbers.Target, S numbers.Source](val S) (result T, err *resPkg.Status) {
+	res, tmpErr := numbers.SafeConvert[T](val)
+	if tmpErr != nil {
+		return 0, &resPkg.Status{
+			Code:       http.StatusInternalServerError,
+			CauseError: tmpErr,
+		}
+	}
+	return res, nil
+}


### PR DESCRIPTION
- add SafeConvert with generic constraints in pkg/numbers
- wrap conversion in utils/numbers with resPkg.Status support
- apply safe casting across gRPC meta setup and handlers