### PR TITLE
fix(docs): correct response type for GET /merchant endpoint

### DIFF
--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -360,7 +360,10 @@ const docTemplaterest = `{
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/response.MerchantUpsert"
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/response.MerchantList"
+                                            }
                                         }
                                     }
                                 }
@@ -1344,6 +1347,27 @@ const docTemplaterest = `{
                 "status": {
                     "type": "string",
                     "example": "UP"
+                }
+            }
+        },
+        "response.MerchantList": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2024-01-14 11:40:00"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 123
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Resik Merchant"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2024-01-14 11:40:00"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -349,7 +349,10 @@
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/response.MerchantUpsert"
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/response.MerchantList"
+                                            }
                                         }
                                     }
                                 }
@@ -1333,6 +1336,27 @@
                 "status": {
                     "type": "string",
                     "example": "UP"
+                }
+            }
+        },
+        "response.MerchantList": {
+            "type": "object",
+            "properties": {
+                "created_at": {
+                    "type": "string",
+                    "example": "2024-01-14 11:40:00"
+                },
+                "id": {
+                    "type": "integer",
+                    "example": 123
+                },
+                "name": {
+                    "type": "string",
+                    "example": "Resik Merchant"
+                },
+                "updated_at": {
+                    "type": "string",
+                    "example": "2024-01-14 11:40:00"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -93,6 +93,21 @@ definitions:
         example: UP
         type: string
     type: object
+  response.MerchantList:
+    properties:
+      created_at:
+        example: "2024-01-14 11:40:00"
+        type: string
+      id:
+        example: 123
+        type: integer
+      name:
+        example: Resik Merchant
+        type: string
+      updated_at:
+        example: "2024-01-14 11:40:00"
+        type: string
+    type: object
   response.MerchantOmzet:
     properties:
       merchant_name:
@@ -383,7 +398,9 @@ paths:
             - $ref: '#/definitions/response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/response.MerchantUpsert'
+                  items:
+                    $ref: '#/definitions/response.MerchantList'
+                  type: array
               type: object
         "400":
           description: Bad Request

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -138,7 +138,7 @@ func (h *Handler) MerchantPut(echoCtx echo.Context) error {
 // @Security BearerAuth
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqMerchantCore.MerchantListGet true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=resMerchantCore.MerchantUpsert}
+// @Success		200	{object}	resPkg.Response{data=[]resMerchantCore.MerchantList}
 // @Failure     400 {object}	resPkg.Response{data=nil}
 // @Failure     404 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}


### PR DESCRIPTION
Changed the Swagger `@Success` response from resMerchantCore.MerchantUpsert to []resMerchantCore.MerchantList to match the actual API output.