### PR TITLE
refactor: rename status return variable to err and use strings.SplitSeq

### DIFF
--- a/core/merchant/merchant.go
+++ b/core/merchant/merchant.go
@@ -14,8 +14,8 @@ import (
 
 //go:generate mockgen -source merchant.go -package mock -destination ./mock/merchant.go
 type IService interface {
-	MerchantInsert(ctx *ctx.Ctx, merchant *merchant.Merchant) (ok bool, status *response.Status)
-	MerchantUpdate(ctx *ctx.Ctx, merchant *merchant.Merchant) (ok bool, status *response.Status)
-	MerchantListGet(param *param.MerchantListGet) (res *dto.MerchantList, status *response.Status)
-	MerchantDelete(ctx *ctx.Ctx, param *merchant.Merchant) (ok bool, status *response.Status)
+	MerchantInsert(ctx *ctx.Ctx, merchant *merchant.Merchant) (ok bool, err *response.Status)
+	MerchantUpdate(ctx *ctx.Ctx, merchant *merchant.Merchant) (ok bool, err *response.Status)
+	MerchantListGet(param *param.MerchantListGet) (res *dto.MerchantList, err *response.Status)
+	MerchantDelete(ctx *ctx.Ctx, param *merchant.Merchant) (ok bool, err *response.Status)
 }

--- a/core/merchant/request/upsert.go
+++ b/core/merchant/request/upsert.go
@@ -13,7 +13,7 @@ import (
 	"github.com/dedyf5/resik/utils/datetime"
 )
 
-func (m *MerchantPost) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, status *resPkg.Status) {
+func (m *MerchantPost) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, err *resPkg.Status) {
 	datetime, err := datetime.FromString(m.GetCreatedAt(), time.RFC3339, ctx)
 	if err != nil {
 		return nil, err
@@ -29,7 +29,7 @@ func (m *MerchantPost) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, sta
 	}, nil
 }
 
-func (m *MerchantPut) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, status *resPkg.Status) {
+func (m *MerchantPut) ToEntity(ctx *ctx.Ctx) (res *merchantEntity.Merchant, err *resPkg.Status) {
 	datetime, err := datetime.FromString(m.GetUpdatedAt(), time.RFC3339, ctx)
 	if err != nil {
 		return nil, err

--- a/core/merchant/service/merchant.go
+++ b/core/merchant/service/merchant.go
@@ -12,22 +12,22 @@ import (
 	resPkg "github.com/dedyf5/resik/pkg/response"
 )
 
-func (s *Service) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (s *Service) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	return s.merchantRepo.MerchantInsert(ctx, merchant)
 }
 
-func (s *Service) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (s *Service) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	return s.merchantRepo.MerchantUpdate(ctx, merchant)
 }
 
-func (s *Service) MerchantListGet(param *paramMerchant.MerchantListGet) (res *dtoMerchant.MerchantList, status *resPkg.Status) {
-	total, status := s.merchantRepo.MerchantListGetTotal(param)
-	if status != nil {
-		return nil, status
+func (s *Service) MerchantListGet(param *paramMerchant.MerchantListGet) (res *dtoMerchant.MerchantList, err *resPkg.Status) {
+	total, err := s.merchantRepo.MerchantListGetTotal(param)
+	if err != nil {
+		return nil, err
 	}
-	data, status := s.merchantRepo.MerchantListGetData(param)
-	if status != nil {
-		return nil, status
+	data, err := s.merchantRepo.MerchantListGetData(param)
+	if err != nil {
+		return nil, err
 	}
 	return &dtoMerchant.MerchantList{
 		Data:  data,
@@ -35,6 +35,6 @@ func (s *Service) MerchantListGet(param *paramMerchant.MerchantListGet) (res *dt
 	}, nil
 }
 
-func (s *Service) MerchantDelete(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (s *Service) MerchantDelete(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	return s.merchantRepo.MerchantDelete(ctx, merchant)
 }

--- a/core/transaction/service/transaction.go
+++ b/core/transaction/service/transaction.go
@@ -10,14 +10,14 @@ import (
 	resPkg "github.com/dedyf5/resik/pkg/response"
 )
 
-func (s *Service) MerchantOmzetGet(param *paramTrx.MerchantOmzetGet) (res *trxDTO.MerchantOmzet, status *resPkg.Status) {
-	total, status := s.transactionRepo.MerchantOmzetGetTotal(param)
-	if status != nil {
-		return nil, status
+func (s *Service) MerchantOmzetGet(param *paramTrx.MerchantOmzetGet) (res *trxDTO.MerchantOmzet, err *resPkg.Status) {
+	total, err := s.transactionRepo.MerchantOmzetGetTotal(param)
+	if err != nil {
+		return nil, err
 	}
-	data, status := s.transactionRepo.MerchantOmzetGetData(param)
-	if status != nil {
-		return nil, status
+	data, err := s.transactionRepo.MerchantOmzetGetData(param)
+	if err != nil {
+		return nil, err
 	}
 	return &trxDTO.MerchantOmzet{
 		Data:  data,
@@ -25,14 +25,14 @@ func (s *Service) MerchantOmzetGet(param *paramTrx.MerchantOmzetGet) (res *trxDT
 	}, nil
 }
 
-func (s *Service) OutletOmzetGet(param *paramTrx.OutletOmzetGet) (res *trxDTO.OutletOmzet, status *resPkg.Status) {
-	total, status := s.transactionRepo.OutletOmzetGetTotal(param)
-	if status != nil {
-		return nil, status
+func (s *Service) OutletOmzetGet(param *paramTrx.OutletOmzetGet) (res *trxDTO.OutletOmzet, err *resPkg.Status) {
+	total, err := s.transactionRepo.OutletOmzetGetTotal(param)
+	if err != nil {
+		return nil, err
 	}
-	data, status := s.transactionRepo.OutletOmzetGetData(param)
-	if status != nil {
-		return nil, status
+	data, err := s.transactionRepo.OutletOmzetGetData(param)
+	if err != nil {
+		return nil, err
 	}
 	return &trxDTO.OutletOmzet{
 		Data:  data,

--- a/core/transaction/transaction.go
+++ b/core/transaction/transaction.go
@@ -12,6 +12,6 @@ import (
 
 //go:generate mockgen -source transaction.go -package mock -destination ./mock/transaction.go
 type IService interface {
-	MerchantOmzetGet(param *paramTrx.MerchantOmzetGet) (res *trxDTO.MerchantOmzet, status *resPkg.Status)
-	OutletOmzetGet(param *paramTrx.OutletOmzetGet) (res *trxDTO.OutletOmzet, status *resPkg.Status)
+	MerchantOmzetGet(param *paramTrx.MerchantOmzetGet) (res *trxDTO.MerchantOmzet, err *resPkg.Status)
+	OutletOmzetGet(param *paramTrx.OutletOmzetGet) (res *trxDTO.OutletOmzet, err *resPkg.Status)
 }

--- a/core/user/service/user.go
+++ b/core/user/service/user.go
@@ -13,7 +13,7 @@ import (
 	resPkg "github.com/dedyf5/resik/pkg/response"
 )
 
-func (s *Service) Auth(param paramUser.Auth) (token string, status *resPkg.Status) {
+func (s *Service) Auth(param paramUser.Auth) (token string, err *resPkg.Status) {
 	user, err := s.userRepo.UserByUsername(param.Ctx, param.Username)
 	if err != nil {
 		return "", err
@@ -36,7 +36,7 @@ func (s *Service) Auth(param paramUser.Auth) (token string, status *resPkg.Statu
 	return s.AuthTokenGenerate(user.ID, user.Username)
 }
 
-func (s *Service) AuthTokenGenerate(userID uint64, username string) (token string, status *resPkg.Status) {
+func (s *Service) AuthTokenGenerate(userID uint64, username string) (token string, err *resPkg.Status) {
 	outlets, err := s.userRepo.OutletMerchantByUserIDGetData(userID)
 	if err != nil {
 		return "", err
@@ -44,6 +44,6 @@ func (s *Service) AuthTokenGenerate(userID uint64, username string) (token strin
 
 	merchantIDs, outletIDs := outlet.GetUniqueMerchantIDsAndOutletIDs(outlets)
 
-	token, status = jwtCtx.AuthTokenGenerate(s.config.App, s.config.Auth, userID, username, merchantIDs, outletIDs)
+	token, err = jwtCtx.AuthTokenGenerate(s.config.App, s.config.Auth, userID, username, merchantIDs, outletIDs)
 	return
 }

--- a/core/user/user.go
+++ b/core/user/user.go
@@ -11,6 +11,6 @@ import (
 
 //go:generate mockgen -source user.go -package mock -destination ./mock/user.go
 type IService interface {
-	Auth(param paramUser.Auth) (token string, status *resPkg.Status)
-	AuthTokenGenerate(userID uint64, username string) (token string, status *resPkg.Status)
+	Auth(param paramUser.Auth) (token string, err *resPkg.Status)
+	AuthTokenGenerate(userID uint64, username string) (token string, err *resPkg.Status)
 }

--- a/ctx/jwt/auth.go
+++ b/ctx/jwt/auth.go
@@ -40,21 +40,21 @@ func (a *AuthClaims) Valid() error {
 	return nil
 }
 
-func (a *AuthClaims) MerchantIDIsAccessible(merchantID uint64) (ok bool, status *resPkg.Status) {
+func (a *AuthClaims) MerchantIDIsAccessible(merchantID uint64) (ok bool, err *resPkg.Status) {
 	if a == nil {
 		return a.statusUnauthorized()
 	}
 	return a.checkAccess(a.MerchantIDs, merchantID)
 }
 
-func (a *AuthClaims) OutletIDIsAccessible(outletID uint64) (ok bool, status *resPkg.Status) {
+func (a *AuthClaims) OutletIDIsAccessible(outletID uint64) (ok bool, err *resPkg.Status) {
 	if a == nil {
 		return a.statusUnauthorized()
 	}
 	return a.checkAccess(a.OutletIDs, outletID)
 }
 
-func (a *AuthClaims) checkAccess(ids []uint64, id uint64) (ok bool, status *resPkg.Status) {
+func (a *AuthClaims) checkAccess(ids []uint64, id uint64) (ok bool, err *resPkg.Status) {
 	if !slices.Contains(ids, id) {
 		return a.statusUnauthorized()
 	}
@@ -67,7 +67,7 @@ func (a *AuthClaims) statusUnauthorized() (bool, *resPkg.Status) {
 	}
 }
 
-func AuthTokenGenerate(appConfig config.App, authConfig config.Auth, userID uint64, username string, merchantIDs []uint64, outletIDs []uint64) (token string, status *resPkg.Status) {
+func AuthTokenGenerate(appConfig config.App, authConfig config.Auth, userID uint64, username string, merchantIDs []uint64, outletIDs []uint64) (token string, err *resPkg.Status) {
 	claims := AuthClaims{
 		RegisteredClaims: jwt.RegisteredClaims{
 			Issuer:    appConfig.Name,
@@ -79,17 +79,17 @@ func AuthTokenGenerate(appConfig config.App, authConfig config.Auth, userID uint
 		OutletIDs:   outletIDs,
 	}
 	tokenGen := jwt.NewWithClaims(AUTH_SIGNING_METHOD, claims)
-	token, err := tokenGen.SignedString([]byte(authConfig.SignatureKey))
-	if err != nil {
+	token, errToken := tokenGen.SignedString([]byte(authConfig.SignatureKey))
+	if errToken != nil {
 		return "", &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errToken,
 		}
 	}
 	return
 }
 
-func AuthClaimsFromString(tokenString string, signatureKey string, lang *lang.Lang) (claim *AuthClaims, status *resPkg.Status) {
+func AuthClaimsFromString(tokenString string, signatureKey string, lang *lang.Lang) (claim *AuthClaims, err *resPkg.Status) {
 	if tokenString == "" {
 		return nil, &resPkg.Status{
 			Code:       http.StatusUnauthorized,
@@ -97,14 +97,14 @@ func AuthClaimsFromString(tokenString string, signatureKey string, lang *lang.La
 			CauseError: errors.New("missing value in request header"),
 		}
 	}
-	token, err := jwt.ParseWithClaims(tokenString, &AuthClaims{}, func(t *jwt.Token) (any, error) {
+	token, errParse := jwt.ParseWithClaims(tokenString, &AuthClaims{}, func(t *jwt.Token) (any, error) {
 		return []byte(signatureKey), nil
 	})
-	if err != nil {
+	if errParse != nil {
 		return nil, &resPkg.Status{
 			Code:       http.StatusUnauthorized,
 			Message:    lang.GetByMessageID("invalid_or_expired_session_login_again"),
-			CauseError: err,
+			CauseError: errParse,
 		}
 	}
 	if claims, ok := token.Claims.(*AuthClaims); ok {

--- a/pkg/goku/order.go
+++ b/pkg/goku/order.go
@@ -31,13 +31,15 @@ func OrdersBuilder(str string) []Order {
 	if str == "" {
 		return res
 	}
-	list := strings.Split(str, ",")
-	for _, v := range list {
+
+	list := strings.SplitSeq(str, ",")
+	for v := range list {
 		if v == "" || v == "-" {
 			continue
 		}
 		res = append(res, OrderBuilder(v))
 	}
+
 	return res
 }
 

--- a/repositories/merchant/merchant.go
+++ b/repositories/merchant/merchant.go
@@ -15,7 +15,7 @@ import (
 	"gorm.io/gorm"
 )
 
-func (r *MerchantRepo) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (r *MerchantRepo) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	result := r.DB.WithContext(ctx.Context).Create(merchant)
 	if result.Error != nil {
 		return false, &resPkg.Status{
@@ -26,7 +26,7 @@ func (r *MerchantRepo) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Mer
 	return true, nil
 }
 
-func (r *MerchantRepo) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (r *MerchantRepo) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	result := r.DB.WithContext(ctx.Context).
 		Exec("UPDATE "+merchantEntity.TABLE_NAME+" SET name = ?, updated_at = ?, updated_by = ? WHERE id = ?", merchant.Name, merchant.UpdatedAt, merchant.UpdatedBy, merchant.ID)
 	if result.Error != nil {
@@ -38,7 +38,7 @@ func (r *MerchantRepo) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Mer
 	return true, nil
 }
 
-func (r *MerchantRepo) MerchantListGetData(param *paramMerchant.MerchantListGet) (merchant []merchantEntity.Merchant, status *resPkg.Status) {
+func (r *MerchantRepo) MerchantListGetData(param *paramMerchant.MerchantListGet) (merchant []merchantEntity.Merchant, err *resPkg.Status) {
 	query := r.MerchantListBaseQuery(param)
 
 	query = query.Select("*").
@@ -61,23 +61,23 @@ func (r *MerchantRepo) MerchantListGetData(param *paramMerchant.MerchantListGet)
 		query = query.Order(order)
 	}
 
-	err := query.Find(&merchant).Error
-	if err != nil {
+	errQuery := query.Find(&merchant).Error
+	if errQuery != nil {
 		return nil, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *MerchantRepo) MerchantListGetTotal(param *paramMerchant.MerchantListGet) (total int64, status *resPkg.Status) {
+func (r *MerchantRepo) MerchantListGetTotal(param *paramMerchant.MerchantListGet) (total int64, err *resPkg.Status) {
 	query := r.MerchantListBaseQuery(param).Select("COUNT(id) AS total")
-	err := query.Take(&total).Error
-	if err != nil {
+	errQuery := query.Take(&total).Error
+	if errQuery != nil {
 		return 0, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
@@ -93,7 +93,7 @@ func (r *MerchantRepo) MerchantListBaseQuery(param *paramMerchant.MerchantListGe
 	return
 }
 
-func (r *MerchantRepo) MerchantDelete(c *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status) {
+func (r *MerchantRepo) MerchantDelete(c *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	if err := r.DB.WithContext(c.Context).Delete(merchant).Error; err != nil {
 		return false, &resPkg.Status{
 			Code:       http.StatusInternalServerError,

--- a/repositories/repository.go
+++ b/repositories/repository.go
@@ -17,10 +17,10 @@ import (
 
 //go:generate mockgen -source repository.go -package mock -destination ./mock/repository.go
 type ITransaction interface {
-	MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet) (res []trxEntity.MerchantOmzet, status *resPkg.Status)
-	MerchantOmzetGetTotal(param *paramTrx.MerchantOmzetGet) (total int64, status *resPkg.Status)
-	OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (res []trxEntity.OutletOmzet, status *resPkg.Status)
-	OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (total int64, status *resPkg.Status)
+	MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet) (res []trxEntity.MerchantOmzet, err *resPkg.Status)
+	MerchantOmzetGetTotal(param *paramTrx.MerchantOmzetGet) (total int64, err *resPkg.Status)
+	OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (res []trxEntity.OutletOmzet, err *resPkg.Status)
+	OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (total int64, err *resPkg.Status)
 	GetMerchantByID(merchantID uint64) (*merchantEntity.Merchant, error)
 	GetMerchantByIDAndUserID(merchantID uint64, userID uint64) (*merchantEntity.Merchant, error)
 	GetOutletByID(outletID uint64) (*outletEntity.Outlet, error)
@@ -28,15 +28,15 @@ type ITransaction interface {
 }
 
 type IUser interface {
-	UserByUsername(ctx *ctx.Ctx, username string) (user *userEntity.User, status *resPkg.Status)
-	MerchantIDsByUserIDGetData(userID uint64) (merchantIDs []uint64, status *resPkg.Status)
-	OutletMerchantByUserIDGetData(userID uint64) (outlets []outletEntity.Outlet, status *resPkg.Status)
+	UserByUsername(ctx *ctx.Ctx, username string) (user *userEntity.User, err *resPkg.Status)
+	MerchantIDsByUserIDGetData(userID uint64) (merchantIDs []uint64, err *resPkg.Status)
+	OutletMerchantByUserIDGetData(userID uint64) (outlets []outletEntity.Outlet, err *resPkg.Status)
 }
 
 type IMerchant interface {
-	MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status)
-	MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status)
-	MerchantListGetData(param *paramMerchant.MerchantListGet) (merchant []merchantEntity.Merchant, status *resPkg.Status)
-	MerchantListGetTotal(param *paramMerchant.MerchantListGet) (total int64, status *resPkg.Status)
-	MerchantDelete(c *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, status *resPkg.Status)
+	MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status)
+	MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status)
+	MerchantListGetData(param *paramMerchant.MerchantListGet) (merchant []merchantEntity.Merchant, err *resPkg.Status)
+	MerchantListGetTotal(param *paramMerchant.MerchantListGet) (total int64, err *resPkg.Status)
+	MerchantDelete(c *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status)
 }

--- a/repositories/transaction/transaction.go
+++ b/repositories/transaction/transaction.go
@@ -16,10 +16,10 @@ import (
 	"gorm.io/gorm"
 )
 
-func (r *TransactionRepo) MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet) (res []trxEntity.MerchantOmzet, status *resPkg.Status) {
-	query, status := r.MerchantOmzetGetQuery(param)
-	if status != nil {
-		return res, status
+func (r *TransactionRepo) MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet) (res []trxEntity.MerchantOmzet, err *resPkg.Status) {
+	query, err := r.MerchantOmzetGetQuery(param)
+	if err != nil {
+		return res, err
 	}
 
 	query = query.
@@ -42,36 +42,36 @@ func (r *TransactionRepo) MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet)
 		query = query.Order(order)
 	}
 
-	err := query.Find(&res).Error
-	if err != nil {
+	errQuery := query.Find(&res).Error
+	if errQuery != nil {
 		return res, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *TransactionRepo) MerchantOmzetGetTotal(param *paramTrx.MerchantOmzetGet) (total int64, status *resPkg.Status) {
-	query, status := r.MerchantOmzetGetQuery(param)
-	if status != nil {
-		return 0, status
+func (r *TransactionRepo) MerchantOmzetGetTotal(param *paramTrx.MerchantOmzetGet) (total int64, err *resPkg.Status) {
+	query, err := r.MerchantOmzetGetQuery(param)
+	if err != nil {
+		return 0, err
 	}
 	query = r.DB.
 		WithContext(param.Ctx.Context).
 		Select("COUNT(x.merchant_id)").
 		Table("(?) AS x", query)
-	err := query.Take(&total).Error
-	if err != nil {
+	errQuery := query.Take(&total).Error
+	if errQuery != nil {
 		return 0, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *TransactionRepo) MerchantOmzetGetQuery(param *paramTrx.MerchantOmzetGet) (query *gorm.DB, status *resPkg.Status) {
+func (r *TransactionRepo) MerchantOmzetGetQuery(param *paramTrx.MerchantOmzetGet) (query *gorm.DB, err *resPkg.Status) {
 	query = r.DB.
 		WithContext(param.Ctx.Context).
 		Select(`
@@ -91,10 +91,10 @@ func (r *TransactionRepo) MerchantOmzetGetQuery(param *paramTrx.MerchantOmzetGet
 	return
 }
 
-func (r *TransactionRepo) OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (res []trxEntity.OutletOmzet, status *resPkg.Status) {
-	query, status := r.OutletOmzetGetQuery(param)
-	if status != nil {
-		return res, status
+func (r *TransactionRepo) OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (res []trxEntity.OutletOmzet, err *resPkg.Status) {
+	query, err := r.OutletOmzetGetQuery(param)
+	if err != nil {
+		return res, err
 	}
 
 	query = query.
@@ -118,17 +118,17 @@ func (r *TransactionRepo) OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (re
 		query = query.Order(order)
 	}
 
-	err := query.Find(&res).Error
-	if err != nil {
+	errQuery := query.Find(&res).Error
+	if errQuery != nil {
 		return res, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *TransactionRepo) OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (total int64, status *resPkg.Status) {
+func (r *TransactionRepo) OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (total int64, err *resPkg.Status) {
 	query, status := r.OutletOmzetGetQuery(param)
 	if status != nil {
 		return 0, status
@@ -137,17 +137,17 @@ func (r *TransactionRepo) OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (t
 		WithContext(param.Ctx.Context).
 		Select("COUNT(x.outlet_id)").
 		Table("(?) AS x", query)
-	err := query.Take(&total).Error
-	if err != nil {
+	errQuery := query.Take(&total).Error
+	if errQuery != nil {
 		return 0, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *TransactionRepo) OutletOmzetGetQuery(param *paramTrx.OutletOmzetGet) (query *gorm.DB, status *resPkg.Status) {
+func (r *TransactionRepo) OutletOmzetGetQuery(param *paramTrx.OutletOmzetGet) (query *gorm.DB, err *resPkg.Status) {
 	query = r.DB.
 		WithContext(param.Ctx.Context).
 		Select(`

--- a/repositories/user/user.go
+++ b/repositories/user/user.go
@@ -16,49 +16,49 @@ import (
 	"gorm.io/gorm"
 )
 
-func (r *UserRepo) UserByUsername(ctx *ctx.Ctx, username string) (user *userEntity.User, status *resPkg.Status) {
+func (r *UserRepo) UserByUsername(ctx *ctx.Ctx, username string) (user *userEntity.User, err *resPkg.Status) {
 	var res userEntity.User
-	err := r.DB.WithContext(ctx.Context).First(&res, "username = ?", username).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+	errQuery := r.DB.WithContext(ctx.Context).First(&res, "username = ?", username).Error
+	if errQuery != nil {
+		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
 		return nil, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return &res, nil
 }
 
-func (r *UserRepo) MerchantIDsByUserIDGetData(userID uint64) (merchantIDs []uint64, status *resPkg.Status) {
+func (r *UserRepo) MerchantIDsByUserIDGetData(userID uint64) (merchantIDs []uint64, err *resPkg.Status) {
 	query := r.DB.Select("id").Table(merchantEntity.TABLE_NAME).Where("user_id = ?", userID)
-	err := query.Find(&merchantIDs).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+	errQuery := query.Find(&merchantIDs).Error
+	if errQuery != nil {
+		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return
 		}
 		return nil, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return
 }
 
-func (r *UserRepo) OutletMerchantByUserIDGetData(userID uint64) (outlets []outletEntity.Outlet, status *resPkg.Status) {
+func (r *UserRepo) OutletMerchantByUserIDGetData(userID uint64) (outlets []outletEntity.Outlet, err *resPkg.Status) {
 	query := r.DB.Select("o1.id, m1.id AS merchant_id").
 		Table(outletEntity.TABLE_NAME+" AS o1").
 		Joins("RIGHT JOIN "+merchantEntity.TABLE_NAME+" AS m1 ON m1.id = o1.merchant_id").
 		Where("m1.user_id = ?", userID)
-	err := query.Find(&outlets).Error
-	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+	errQuery := query.Find(&outlets).Error
+	if errQuery != nil {
+		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return
 		}
 		return nil, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
-			CauseError: err,
+			CauseError: errQuery,
 		}
 	}
 	return

--- a/utils/datetime/datetime.go
+++ b/utils/datetime/datetime.go
@@ -8,13 +8,13 @@ import (
 	resPkg "github.com/dedyf5/resik/pkg/response"
 )
 
-func FromString(val string, format string, c *ctx.Ctx) (res *time.Time, status *resPkg.Status) {
-	datetime, err := time.Parse(format, val)
-	if err != nil {
+func FromString(val string, format string, c *ctx.Ctx) (res *time.Time, err *resPkg.Status) {
+	datetime, errParse := time.Parse(format, val)
+	if errParse != nil {
 		return nil, &resPkg.Status{
 			Code:       http.StatusInternalServerError,
 			Message:    c.Lang().GetByMessageID("invalid_time_format"),
-			CauseError: err,
+			CauseError: errParse,
 		}
 	}
 


### PR DESCRIPTION
- refactor: rename status return variable to err for better clarity
- perf: migrate strings.Split to strings.SplitSeq in OrdersBuilder