### PR TITLE
refactor: standardize status creation and logging context

### DIFF
--- a/app/grpc/handler/health/health.go
+++ b/app/grpc/handler/health/health.go
@@ -31,10 +31,7 @@ func New(hs coreHealth.IService) *HealthHandler {
 func (h *HealthHandler) HealthzGet(c context.Context, _ *emptypb.Empty) (*HealthHealthzGetRes, error) {
 	isLive, statusMsg := h.healthService.LivenessCheck(c)
 	if !isLive {
-		return nil, &resPkg.Status{
-			Code:    http.StatusServiceUnavailable,
-			Message: "NOT_SERVING",
-		}
+		return nil, resPkg.NewStatusMessage(http.StatusServiceUnavailable, "NOT_SERVING", nil)
 	}
 
 	return &HealthHealthzGetRes{

--- a/app/grpc/middleware/interceptor.go
+++ b/app/grpc/middleware/interceptor.go
@@ -67,8 +67,8 @@ func (i *Interceptor) logCtx(c context.Context, path string) (*context.Context, 
 
 	correlationID := xid.New().String()
 	newMeta := meta.Copy()
-	newMeta.Append(logCtx.CorrelationIDKeyContext.String(), correlationID)
-	newMeta.Append(logCtx.CorrelationIDKeyXHeader.String(), correlationID)
+	newMeta.Append(logCtx.KeyCorrelationIDContext.String(), correlationID)
+	newMeta.Append(logCtx.KeyXCorrelationIDHeader.String(), correlationID)
 
 	i.log.CorrelationID = correlationID
 	i.log.Path = path
@@ -78,8 +78,8 @@ func (i *Interceptor) logCtx(c context.Context, path string) (*context.Context, 
 	return &newCtx, nil
 }
 
-func (i *Interceptor) writeLogger(start time.Time, fullMethod string, req any, res any, err error) (any, error) {
-	logger := logCtx.NewGRPC(i.app.Module, i.log, start, fullMethod, req, res, err)
+func (i *Interceptor) writeLogger(c context.Context, start time.Time, fullMethod string, req any, res any, err error) (any, error) {
+	logger := logCtx.NewGRPC(i.app.Module, c, i.log, start, fullMethod, req, res, err)
 	logger.Write()
 	return res, err
 }
@@ -87,10 +87,7 @@ func (i *Interceptor) writeLogger(start time.Time, fullMethod string, req any, r
 func (i *Interceptor) langCtx(c context.Context, langDefault language.Tag) (*context.Context, *langCtx.Lang, error) {
 	meta, ok := metadata.FromIncomingContext(c)
 	if !ok {
-		return nil, nil, &resPkg.Status{
-			Code:    http.StatusInternalServerError,
-			Message: "Unable to read metadata",
-		}
+		return nil, nil, resPkg.NewStatusMessage(http.StatusInternalServerError, "unable to read metadata", nil)
 	}
 	var langReq *language.Tag = nil
 	langKey := langCtx.ContextKey.String()
@@ -121,9 +118,7 @@ func (i *Interceptor) validateJWT(c context.Context, lang *langCtx.Lang, signatu
 		return &c, nil
 	}
 	if len(meta["authorization"]) != 1 {
-		return nil, &resPkg.Status{
-			Code: http.StatusUnauthorized,
-		}
+		return nil, resPkg.NewStatusCode(http.StatusUnauthorized)
 	}
 	bearer := meta["authorization"][0]
 	token := strings.ReplaceAll(bearer, "Bearer ", "")
@@ -137,14 +132,15 @@ func (i *Interceptor) validateJWT(c context.Context, lang *langCtx.Lang, signatu
 }
 
 func (i *Interceptor) errorMetadata() (*context.Context, error) {
-	return nil, &resPkg.Status{
-		Code:    http.StatusInternalServerError,
-		Message: "Unable to read metadata",
-	}
+	return nil, resPkg.NewStatusMessage(http.StatusInternalServerError, "unable to read metadata", nil)
 }
 
 func (i *Interceptor) Unary(c context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 	start := time.Now()
+
+	callerHolder := &logCtx.CallerHolder{}
+
+	c = context.WithValue(c, logCtx.KeyCallerHolderContext, callerHolder)
 
 	logC, err := i.logCtx(c, info.FullMethod)
 	if err != nil {
@@ -153,15 +149,15 @@ func (i *Interceptor) Unary(c context.Context, req any, info *grpc.UnaryServerIn
 
 	langC, langRes, err := i.langCtx(*logC, i.app.LangDefault)
 	if err != nil {
-		return i.writeLogger(start, info.FullMethod, req, nil, err)
+		return i.writeLogger(c, start, info.FullMethod, req, nil, err)
 	}
 
 	tokenC, err := i.validateJWT(*langC, langRes, i.auth.SignatureKey, info.FullMethod)
 	if err != nil {
-		return i.writeLogger(start, info.FullMethod, req, nil, err)
+		return i.writeLogger(c, start, info.FullMethod, req, nil, err)
 	}
 
 	res, err := handler(*tokenC, req)
 
-	return i.writeLogger(start, info.FullMethod, req, res, err)
+	return i.writeLogger(c, start, info.FullMethod, req, res, err)
 }

--- a/app/rest/fw/echo/binder.go
+++ b/app/rest/fw/echo/binder.go
@@ -155,13 +155,13 @@ func (b *bind) ParamValidator(c echo.Context, i any) error {
 				"expected": ft,
 				"actual":   "string",
 			})
-			return &resPkg.Status{
-				Code:    http.StatusBadRequest,
-				Message: msg,
-				Detail: map[string]string{
+			return resPkg.NewStatusDetail(
+				http.StatusBadRequest,
+				msg,
+				map[string]string{
 					fn: msg,
 				},
-			}
+			)
 		}
 
 		return nil
@@ -201,11 +201,7 @@ func (b *bind) JSONErrorFormatter(c echo.Context, err error) error {
 			"expected": expecteds[1],
 			"actual":   gots[1],
 		})
-		return &resPkg.Status{
-			Code:    http.StatusBadRequest,
-			Message: errMap[field],
-			Detail:  errMap,
-		}
+		return resPkg.NewStatusDetail(http.StatusBadRequest, errMap[field], errMap)
 	}
 
 	return nil

--- a/app/rest/fw/echo/echo.go
+++ b/app/rest/fw/echo/echo.go
@@ -57,15 +57,16 @@ func HTTPErrorHandler(err error, ctx echo.Context) {
 	}
 
 	if res, ok := errors.AsType[*echo.HTTPError](err); ok {
-		_ = ctx.JSON(res.Code, httpUtil.LoggerFromStatus(&resPkg.Status{
-			Code:    res.Code,
-			Message: fmt.Sprintf("%s", res.Message),
-		}))
+		msg := fmt.Sprintf("%s", res.Message)
+		statusRes := resPkg.NewStatusMessage(res.Code, msg, nil)
+		_ = ctx.JSON(
+			res.Code,
+			httpUtil.LoggerFromStatus(statusRes),
+		)
 		return
 	}
 
-	_ = ctx.JSON(http.StatusInternalServerError, httpUtil.LoggerErrorAuto(&resPkg.Status{
-		Code:       http.StatusInternalServerError,
-		CauseError: err,
-	}))
+	statusRes := resPkg.NewStatusError(http.StatusInternalServerError, err)
+
+	_ = ctx.JSON(http.StatusInternalServerError, httpUtil.LoggerErrorAuto(statusRes))
 }

--- a/app/rest/fw/echo/middleware.go
+++ b/app/rest/fw/echo/middleware.go
@@ -72,21 +72,25 @@ func LoggerAndResponseFormatterMiddleware(log *logCtx.Log, appModule config.Modu
 			}
 
 			correlationID := xid.New().String()
-			ctx := context.WithValue(
+			c := context.WithValue(
 				r.Context(),
-				logCtx.CorrelationIDKeyContext,
+				logCtx.KeyCorrelationIDContext,
 				correlationID,
 			)
 
-			r = r.WithContext(ctx)
+			callerHolder := &logCtx.CallerHolder{}
+
+			c = context.WithValue(c, logCtx.KeyCallerHolderContext, callerHolder)
+
+			r = r.WithContext(c)
 
 			log.CorrelationID = correlationID
 			log.Path = r.URL.Path
 			log.QueryString = &r.URL.RawQuery
 
-			w.Header().Add(logCtx.CorrelationIDKeyXHeader.String(), correlationID)
+			w.Header().Add(logCtx.KeyXCorrelationIDHeader.String(), correlationID)
 
-			lrw := logCtx.NewHTTP(w, appModule, log, time.Now(), r.Method, r.URL, contentType, r.UserAgent(), requestBody)
+			lrw := logCtx.NewHTTP(w, appModule, c, log, time.Now(), r.Method, r.URL, contentType, r.UserAgent(), requestBody)
 
 			h.ServeHTTP(lrw, r)
 		})
@@ -103,10 +107,7 @@ func ValidateTokenMiddleware(signatureKey string) echo.MiddlewareFunc {
 			ctx := c.Request().Context()
 			langRes, langErr := langCtx.FromContext(ctx)
 			if langErr != nil {
-				return &resPkg.Status{
-					Code:       http.StatusInternalServerError,
-					CauseError: langErr,
-				}
+				return resPkg.NewStatusError(http.StatusInternalServerError, langErr)
 			}
 			return jwtCtx.HTTPStatusError(err, langRes)
 		},

--- a/app/rest/handler/general/handler.go
+++ b/app/rest/handler/general/handler.go
@@ -54,9 +54,12 @@ func (h *Handler) Home(echoCtx echo.Context) error {
 	}
 
 	lang := ctx.Lang()
-	return &resPkg.Status{
-		Code:    http.StatusOK,
-		Message: lang.GetByTemplateData("home_message", commonEntity.Map{"app_name": h.config.App.Name, "code": h.config.App.Version}),
-		Data:    resAppCore.AppMap(ctx, h.config, &payload),
-	}
+
+	msg := lang.GetByTemplateData("home_message", commonEntity.Map{"app_name": h.config.App.Name, "code": h.config.App.Version})
+
+	return resPkg.NewStatusSuccess(
+		http.StatusOK,
+		msg,
+		resAppCore.AppMap(ctx, h.config, &payload),
+	)
 }

--- a/app/rest/handler/health/handler.go
+++ b/app/rest/handler/health/handler.go
@@ -55,13 +55,13 @@ func (h *HealthHandler) HealthHealthzGet(echoCtx echo.Context) error {
 		code = http.StatusServiceUnavailable
 	}
 
-	return &resPkg.Status{
-		Code:    code,
-		Message: statusMsg,
-		Data: &response.HealthHealthz{
+	return resPkg.NewStatusSuccess(
+		code,
+		statusMsg,
+		&response.HealthHealthz{
 			AccessedAt: time.Now().UTC().Format(time.RFC3339),
 		},
-	}
+	)
 }
 
 // @Summary Readiness check
@@ -87,13 +87,13 @@ func (h *HealthHandler) HealthReadyzGet(echoCtx echo.Context) error {
 		httpStatus = http.StatusServiceUnavailable
 	}
 
-	return &resPkg.Status{
-		Code:    httpStatus,
-		Message: string(status.OverallStatus),
-		Data: &response.HealthReadyz{
+	return resPkg.NewStatusSuccess(
+		httpStatus,
+		string(status.OverallStatus),
+		&response.HealthReadyz{
 			OverallStatus: string(status.OverallStatus),
 			AccessedAt:    status.Timestamp.UTC().Format(time.RFC3339),
 			Checks:        response.HealthReadyzCheckFromCheckDetail(status.Checks),
 		},
-	}
+	)
 }

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -67,15 +67,15 @@ func (h *Handler) MerchantPost(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusCreated,
-		Message: ctx.Lang().GetByTemplateData("successfully_created_val", commonEntity.Map{
-			"val": "merchant",
-		}),
-		Data: &resMerchantCore.MerchantUpsert{
+	msg := ctx.Lang().GetByTemplateData("successfully_created_val", commonEntity.Map{"val": "merchant"})
+
+	return resPkg.NewStatusSuccess(
+		http.StatusCreated,
+		msg,
+		&resMerchantCore.MerchantUpsert{
 			Id: entity.ID,
 		},
-	}
+	)
 }
 
 // @Summary Update Merchant
@@ -119,15 +119,15 @@ func (h *Handler) MerchantPut(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusOK,
-		Message: ctx.Lang().GetByTemplateData("successfully_updated_val", commonEntity.Map{
-			"val": "merchant",
-		}),
-		Data: &resMerchantCore.MerchantUpsert{
+	msg := ctx.Lang().GetByTemplateData("successfully_updated_val", commonEntity.Map{"val": "merchant"})
+
+	return resPkg.NewStatusSuccess(
+		http.StatusOK,
+		msg,
+		&resMerchantCore.MerchantUpsert{
 			Id: entity.ID,
 		},
-	}
+	)
 }
 
 // @Summary Merchant List
@@ -168,15 +168,15 @@ func (h *Handler) MerchantListGet(echoCtx echo.Context) error {
 		code = http.StatusNotFound
 	}
 
-	return &resPkg.Status{
-		Code: code,
-		Data: resMerchantCore.MerchantListFromEntity(res.Data),
-		Meta: &resPkg.Meta{
+	return resPkg.NewStatusDataMeta(
+		code,
+		resMerchantCore.MerchantListFromEntity(res.Data),
+		&resPkg.Meta{
 			PageCurrent: param.Filter.Raw().PageOrDefault(),
 			Limit:       param.Filter.Raw().LimitOrDefault(),
 			Total:       res.Total,
 		},
-	}
+	)
 }
 
 // @Summary Update Merchant
@@ -214,7 +214,5 @@ func (h *Handler) MerchantDelete(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusNoContent,
-	}
+	return resPkg.NewStatusCode(http.StatusNoContent)
 }

--- a/app/rest/handler/transaction/handler.go
+++ b/app/rest/handler/transaction/handler.go
@@ -79,15 +79,15 @@ func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusOK,
-		Data: resTrxCore.MerchantOmzetFromEntity(res.Data),
-		Meta: &resPkg.Meta{
+	return resPkg.NewStatusDataMeta(
+		http.StatusOK,
+		resTrxCore.MerchantOmzetFromEntity(res.Data),
+		&resPkg.Meta{
 			PageCurrent: param.Filter.Raw().PageOrDefault(),
 			Limit:       param.Filter.Raw().LimitOrDefault(),
 			Total:       res.Total,
 		},
-	}
+	)
 }
 
 // @Summary Get Outlet Omzet
@@ -129,13 +129,13 @@ func (h *Handler) OutletOmzetGet(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusOK,
-		Data: resTrxCore.OutletOmzetFromEntity(res.Data),
-		Meta: &resPkg.Meta{
+	return resPkg.NewStatusDataMeta(
+		http.StatusOK,
+		resTrxCore.OutletOmzetFromEntity(res.Data),
+		&resPkg.Meta{
 			PageCurrent: param.Filter.Raw().PageOrDefault(),
 			Limit:       param.Filter.Raw().LimitOrDefault(),
 			Total:       res.Total,
 		},
-	}
+	)
 }

--- a/app/rest/handler/user/handler.go
+++ b/app/rest/handler/user/handler.go
@@ -63,13 +63,13 @@ func (h *Handler) LoginPost(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusOK,
-		Data: resUserCore.UserCredential{
+	return resPkg.NewStatusData(
+		http.StatusOK,
+		resUserCore.UserCredential{
 			Username: payload.GetUsername(),
 			Token:    token,
 		},
-	}
+	)
 }
 
 // @Summary Token Refresh
@@ -100,11 +100,11 @@ func (h *Handler) TokenRefreshGet(echoCtx echo.Context) error {
 		return err
 	}
 
-	return &resPkg.Status{
-		Code: http.StatusOK,
-		Data: resUserCore.UserCredential{
+	return resPkg.NewStatusData(
+		http.StatusOK,
+		resUserCore.UserCredential{
 			Username: ctx.UserClaims().Username,
 			Token:    token,
 		},
-	}
+	)
 }

--- a/core/user/service/user.go
+++ b/core/user/service/user.go
@@ -19,18 +19,11 @@ func (s *Service) Auth(param paramUser.Auth) (token string, err *resPkg.Status) 
 		return "", err
 	}
 	if user == nil {
-		return "", &resPkg.Status{
-			Code:    http.StatusUnauthorized,
-			Message: param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"),
-		}
+		return "", resPkg.NewStatusMessage(http.StatusUnauthorized, param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"), nil)
 	}
 
 	if ok, err := s.hasher.Compare(param.Password, user.Password); !ok || err != nil {
-		return "", &resPkg.Status{
-			Code:       http.StatusUnauthorized,
-			Message:    param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"),
-			CauseError: err,
-		}
+		return "", resPkg.NewStatusMessage(http.StatusUnauthorized, param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"), err)
 	}
 
 	return s.AuthTokenGenerate(user.ID, user.Username)

--- a/core/user/service/user_test.go
+++ b/core/user/service/user_test.go
@@ -64,13 +64,11 @@ func TestAuth(t *testing.T) {
 		gomock.InOrder(
 			userRepo.EXPECT().UserByUsername(param.Ctx, param.Username).Return(nil, nil),
 		)
-		statusErr := &resPkg.Status{
-			Code:    http.StatusUnauthorized,
-			Message: param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"),
-		}
+		statusErr := resPkg.NewStatusMessage(http.StatusUnauthorized, param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"), nil)
 		token, err := userService.Auth(param)
 		assert.NotNil(t, err)
-		assert.Equal(t, statusErr, err)
+		assert.Equal(t, statusErr.Code, err.Code)
+		assert.Equal(t, statusErr.Message, err.Message)
 		assert.Empty(t, token)
 	})
 
@@ -79,13 +77,11 @@ func TestAuth(t *testing.T) {
 			userRepo.EXPECT().UserByUsername(param.Ctx, param.Username).Return(userExpected, nil),
 			hasher.EXPECT().Compare(param.Password, userExpected.Password).Return(false, nil),
 		)
-		statusErr := &resPkg.Status{
-			Code:    http.StatusUnauthorized,
-			Message: param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"),
-		}
+		statusErr := resPkg.NewStatusMessage(http.StatusUnauthorized, param.Ctx.Lang().GetByMessageID("incorrect_username_or_password"), nil)
 		token, err := userService.Auth(param)
 		assert.NotNil(t, err)
-		assert.Equal(t, statusErr, err)
+		assert.Equal(t, statusErr.Code, err.Code)
+		assert.Equal(t, statusErr.Message, err.Message)
 		assert.Empty(t, token)
 	})
 

--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -6,17 +6,13 @@ package ctx
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 
 	jwt "github.com/dedyf5/resik/ctx/jwt"
 	lang "github.com/dedyf5/resik/ctx/lang"
 	logCtx "github.com/dedyf5/resik/ctx/log"
 	resPkg "github.com/dedyf5/resik/pkg/response"
-)
-
-type Key string
-
-const (
-	KeyFullMethod Key = "FullMethod"
 )
 
 type Ctx struct {
@@ -30,10 +26,18 @@ type Ctx struct {
 //
 // error status code: 500
 func NewCtx(c context.Context, log *logCtx.Log) (*Ctx, *resPkg.Status) {
+	_, file, line, _ := runtime.Caller(1)
+	caller := fmt.Sprintf("%s:%d", file, line)
+
+	if holder, ok := c.Value(logCtx.KeyCallerHolderContext).(*logCtx.CallerHolder); ok {
+		holder.Caller = &caller
+	}
+
 	langRes, err := lang.FromContext(c)
 	if err != nil {
 		return nil, err
 	}
+
 	return &Ctx{
 		Context:    c,
 		lang:       langRes,

--- a/ctx/jwt/auth.go
+++ b/ctx/jwt/auth.go
@@ -62,9 +62,7 @@ func (a *AuthClaims) checkAccess(ids []uint64, id uint64) (ok bool, err *resPkg.
 }
 
 func (a *AuthClaims) statusUnauthorized() (bool, *resPkg.Status) {
-	return false, &resPkg.Status{
-		Code: http.StatusUnauthorized,
-	}
+	return false, resPkg.NewStatusCode(http.StatusUnauthorized)
 }
 
 func AuthTokenGenerate(appConfig config.App, authConfig config.Auth, userID uint64, username string, merchantIDs []uint64, outletIDs []uint64) (token string, err *resPkg.Status) {
@@ -81,40 +79,37 @@ func AuthTokenGenerate(appConfig config.App, authConfig config.Auth, userID uint
 	tokenGen := jwt.NewWithClaims(AUTH_SIGNING_METHOD, claims)
 	token, errToken := tokenGen.SignedString([]byte(authConfig.SignatureKey))
 	if errToken != nil {
-		return "", &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errToken,
-		}
+		return "", resPkg.NewStatusError(http.StatusInternalServerError, errToken)
 	}
 	return
 }
 
 func AuthClaimsFromString(tokenString string, signatureKey string, lang *lang.Lang) (claim *AuthClaims, err *resPkg.Status) {
 	if tokenString == "" {
-		return nil, &resPkg.Status{
-			Code:       http.StatusUnauthorized,
-			Message:    lang.GetByMessageID("unauthorized"),
-			CauseError: errors.New("missing value in request header"),
-		}
+		return nil, resPkg.NewStatusMessage(
+			http.StatusUnauthorized,
+			lang.GetByMessageID("unauthorized"),
+			errors.New("missing value in request header"),
+		)
 	}
 	token, errParse := jwt.ParseWithClaims(tokenString, &AuthClaims{}, func(t *jwt.Token) (any, error) {
 		return []byte(signatureKey), nil
 	})
 	if errParse != nil {
-		return nil, &resPkg.Status{
-			Code:       http.StatusUnauthorized,
-			Message:    lang.GetByMessageID("invalid_or_expired_session_login_again"),
-			CauseError: errParse,
-		}
+		return nil, resPkg.NewStatusMessage(
+			http.StatusUnauthorized,
+			lang.GetByMessageID("invalid_or_expired_session_login_again"),
+			errParse,
+		)
 	}
 	if claims, ok := token.Claims.(*AuthClaims); ok {
 		return claims, nil
 	}
-	return nil, &resPkg.Status{
-		Code:       http.StatusUnauthorized,
-		Message:    lang.GetByMessageID("invalid_or_expired_session_login_again"),
-		CauseError: errors.New("error while casting AuthClaims"),
-	}
+	return nil, resPkg.NewStatusMessage(
+		http.StatusUnauthorized,
+		lang.GetByMessageID("invalid_or_expired_session_login_again"),
+		errors.New("error while casting AuthClaims"),
+	)
 }
 
 func AuthClaimsFromContext(ctx context.Context) *AuthClaims {
@@ -130,15 +125,15 @@ func AuthClaimsFromContext(ctx context.Context) *AuthClaims {
 
 func HTTPStatusError(err error, lang *lang.Lang) *resPkg.Status {
 	if strings.Contains(err.Error(), "invalid") {
-		return &resPkg.Status{
-			Code:       http.StatusUnauthorized,
-			Message:    lang.GetByMessageID("invalid_or_expired_session_login_again"),
-			CauseError: err,
-		}
+		return resPkg.NewStatusMessage(
+			http.StatusUnauthorized,
+			lang.GetByMessageID("invalid_or_expired_session_login_again"),
+			err,
+		)
 	}
-	return &resPkg.Status{
-		Code:       http.StatusUnauthorized,
-		Message:    lang.GetByMessageID("unauthorized"),
-		CauseError: err,
-	}
+	return resPkg.NewStatusMessage(
+		http.StatusUnauthorized,
+		lang.GetByMessageID("unauthorized"),
+		err,
+	)
 }

--- a/ctx/lang/lang.go
+++ b/ctx/lang/lang.go
@@ -71,10 +71,10 @@ func FromContext(ctx context.Context) (*Lang, *resPkg.Status) {
 	if lang, ok := ctx.Value(ContextKey).(*Lang); ok {
 		return lang, nil
 	}
-	return nil, &resPkg.Status{
-		Code:       http.StatusInternalServerError,
-		CauseError: errors.New("failed to casting lang from context"),
-	}
+	return nil, resPkg.NewStatusError(
+		http.StatusInternalServerError,
+		errors.New("failed to casting lang from context"),
+	)
 }
 
 func (src *Lang) GetByMessageID(id string) string {
@@ -122,10 +122,7 @@ func GetLanguageAvailable(lang string) (*language.Tag, *resPkg.Status) {
 	}
 	res, err := language.Parse(lang)
 	if err != nil {
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: err,
-		}
+		return nil, resPkg.NewStatusError(http.StatusInternalServerError, err)
 	}
 	return &res, nil
 }
@@ -136,13 +133,13 @@ func GetLanguageAvailable(lang string) (*language.Tag, *resPkg.Status) {
 func LanguageIsAvailable(lang string) (bool, *resPkg.Status) {
 	if lang == "" {
 		msg := "lang is required"
-		return false, &resPkg.Status{
-			Code:    http.StatusBadRequest,
-			Message: msg,
-			Detail: map[string]string{
+		return false, resPkg.NewStatusDetail(
+			http.StatusBadRequest,
+			msg,
+			map[string]string{
 				ContextKey.String(): msg,
 			},
-		}
+		)
 	}
 	langCodes := make([]string, 0, cap(Available))
 	for _, v := range Available {
@@ -150,13 +147,13 @@ func LanguageIsAvailable(lang string) (bool, *resPkg.Status) {
 	}
 	if !slices.Contains(langCodes, lang) {
 		msg := fmt.Sprintf("lang must be one of [%s]", strings.Join(langCodes, ", "))
-		return false, &resPkg.Status{
-			Code:    http.StatusBadRequest,
-			Message: msg,
-			Detail: map[string]string{
+		return false, resPkg.NewStatusDetail(
+			http.StatusBadRequest,
+			msg,
+			map[string]string{
 				ContextKey.String(): msg,
 			},
-		}
+		)
 	}
 	return true, nil
 }

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -5,6 +5,7 @@
 package log
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -20,6 +21,7 @@ import (
 
 type GRPC struct {
 	appModule    configEntity.Module
+	context      context.Context
 	log          *Log
 	start        time.Time
 	status       *resPkg.Status
@@ -47,10 +49,8 @@ var sensitiveFields = map[string]struct{}{
 	"token":    {},
 }
 
-func NewGRPC(appModule configEntity.Module, log *Log, start time.Time, path string, requestBody any, responseBody any, err error) *GRPC {
-	status := &resPkg.Status{
-		Code: http.StatusOK,
-	}
+func NewGRPC(appModule configEntity.Module, c context.Context, log *Log, start time.Time, path string, requestBody any, responseBody any, err error) *GRPC {
+	status := resPkg.NewStatusCode(http.StatusOK)
 
 	if s := statusProto.Extract(responseBody); s != nil {
 		status.Message = s.GetMessage()
@@ -64,6 +64,7 @@ func NewGRPC(appModule configEntity.Module, log *Log, start time.Time, path stri
 
 	return &GRPC{
 		appModule:    appModule,
+		context:      c,
 		log:          log,
 		start:        start,
 		status:       status,
@@ -74,13 +75,34 @@ func NewGRPC(appModule configEntity.Module, log *Log, start time.Time, path stri
 }
 
 func (h *GRPC) Write() {
+	logger := h.log.logger
+
+	fields := []zap.Field{zap.Inline(h)}
+
+	caller := ""
+	if holder, ok := h.context.Value(KeyCallerHolderContext).(*CallerHolder); ok {
+		caller = *holder.Caller
+	}
+
+	if h.status.Caller != "" {
+		caller = h.status.Caller
+	}
+
+	if caller != "" {
+		fields = append(fields, zap.String("line", caller))
+		logger = logger.WithOptions(zap.WithCaller(false))
+	}
+
 	switch {
 	case h.status.Code >= http.StatusOK && h.status.Code <= http.StatusIMUsed:
-		h.log.logger.Info(h.status.MessageOrDefault(), zap.Inline(h))
+		logger.Info(h.status.MessageOrDefault(), fields...)
 	case h.status.Code >= http.StatusInternalServerError && h.status.Code <= http.StatusNetworkAuthenticationRequired:
-		h.log.logger.Error(h.status.CauseErrorMessageOrDefault(), zap.Inline(h))
+		if h.status.StackTrace != nil {
+			fields = append(fields, zap.Strings("stack_trace", h.status.StackTrace))
+		}
+		logger.Error(h.status.CauseErrorMessageOrDefault(), fields...)
 	default:
-		h.log.logger.Warn(h.status.CauseErrorMessageOrDefault(), zap.Inline(h))
+		logger.Warn(h.status.CauseErrorMessageOrDefault(), fields...)
 	}
 }
 
@@ -88,7 +110,7 @@ func (h *GRPC) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	grpc := h.status.GRPCStatus()
 
 	enc.AddString("module", h.appModule.DirectoryName())
-	enc.AddString(CorrelationIDKeyContext.String(), h.log.CorrelationID)
+	enc.AddString(KeyCorrelationIDContext.String(), h.log.CorrelationID)
 	enc.AddString("path", h.path)
 	enc.AddUint32("status_code", uint32(grpc.Code()))
 	enc.AddInt64("elapsed_micro", time.Since(h.start).Microseconds())

--- a/ctx/log/http.go
+++ b/ctx/log/http.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/url"
@@ -21,6 +22,7 @@ import (
 type HTTP struct {
 	http.ResponseWriter
 	appModule    configEntity.Module
+	context      context.Context
 	log          *Log
 	start        time.Time
 	statusCode   int
@@ -32,9 +34,9 @@ type HTTP struct {
 	responseBody *bytes.Buffer
 }
 
-func NewHTTP(w http.ResponseWriter, appModule configEntity.Module, log *Log, start time.Time, method string, url *url.URL, contentType, userAgent string, requestBody []byte) *HTTP {
+func NewHTTP(w http.ResponseWriter, appModule configEntity.Module, c context.Context, log *Log, start time.Time, method string, url *url.URL, contentType, userAgent string, requestBody []byte) *HTTP {
 	var buf bytes.Buffer
-	return &HTTP{w, appModule, log, start, http.StatusOK, method, url, contentType, userAgent, requestBody, &buf}
+	return &HTTP{w, appModule, c, log, start, http.StatusOK, method, url, contentType, userAgent, requestBody, &buf}
 }
 
 func (h *HTTP) WriteHeader(code int) {
@@ -59,19 +61,40 @@ func (h *HTTP) writeLogger(loggerRes *resPkg.Log) {
 		msg = loggerRes.Message
 	}
 
+	logger := h.log.logger
+
+	fields := []zap.Field{zap.Inline(h)}
+
+	caller := ""
+	if holder, ok := h.context.Value(KeyCallerHolderContext).(*CallerHolder); ok {
+		caller = *holder.Caller
+	}
+
+	if loggerRes.Caller != "" {
+		caller = loggerRes.Caller
+	}
+
+	if caller != "" {
+		fields = append(fields, zap.String("line", caller))
+		logger = logger.WithOptions(zap.WithCaller(false))
+	}
+
 	switch {
 	case h.statusCode >= http.StatusOK && h.statusCode <= http.StatusIMUsed:
-		h.log.logger.Info(msg, zap.Inline(h))
+		logger.Info(msg, fields...)
 	case h.statusCode >= http.StatusInternalServerError && h.statusCode <= http.StatusNetworkAuthenticationRequired:
-		h.log.logger.Error(msg, zap.Inline(h))
+		if loggerRes.StackTrace != nil {
+			fields = append(fields, zap.Strings("stack_trace", loggerRes.StackTrace))
+		}
+		logger.Error(msg, fields...)
 	default:
-		h.log.logger.Warn(msg, zap.Inline(h))
+		logger.Warn(msg, fields...)
 	}
 }
 
 func (h *HTTP) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddString("module", h.appModule.DirectoryName())
-	enc.AddString(CorrelationIDKeyContext.String(), h.log.CorrelationID)
+	enc.AddString(KeyCorrelationIDContext.String(), h.log.CorrelationID)
 	enc.AddString("method", h.method)
 	enc.AddString("path", h.url.Path)
 	enc.AddString("query_string", h.url.RawQuery)

--- a/ctx/log/log.go
+++ b/ctx/log/log.go
@@ -28,12 +28,17 @@ type Log struct {
 	QueryString   *string
 }
 
-type CorrelationIDKey string
+type Key string
 
 const (
-	CorrelationIDKeyContext CorrelationIDKey = "correlation_id"
-	CorrelationIDKeyXHeader CorrelationIDKey = "X-Correlation-ID"
+	KeyCorrelationIDContext Key = "correlation_id"
+	KeyXCorrelationIDHeader Key = "X-Correlation-ID"
+	KeyCallerHolderContext  Key = "caller"
 )
+
+type CallerHolder struct {
+	Caller *string
+}
 
 var once sync.Once
 
@@ -52,18 +57,23 @@ var logLevelSeverity = map[zapcore.Level]string{
 func Get(logEntity configEntity.Log, appModule configEntity.Module) *Log {
 	once.Do(func() {
 		stdout := zapcore.AddSync(os.Stdout)
+
 		encoderConfig := zapcore.EncoderConfig{
-			MessageKey:    "message",
-			LevelKey:      "level",
-			EncodeLevel:   CustomEncodeLevel,
-			TimeKey:       "time",
-			EncodeTime:    zapcore.TimeEncoderOfLayout(time.RFC3339),
+			MessageKey:  "message",
+			LevelKey:    "level",
+			EncodeLevel: CustomEncodeLevel,
+			TimeKey:     "time",
+			EncodeTime: func(t time.Time, pae zapcore.PrimitiveArrayEncoder) {
+				pae.AppendString(t.UTC().Format("2006-01-02T15:04:05Z"))
+			},
 			CallerKey:     "line",
 			EncodeCaller:  zapcore.FullCallerEncoder,
 			StacktraceKey: "stack_trace",
 		}
+
 		coreConfig := []zapcore.Core{}
 		coreConfig = append(coreConfig, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), stdout, zap.DebugLevel))
+
 		if logEntity.File != "" {
 			logFile := zapcore.AddSync(&lumberjack.Logger{
 				Filename:   logEntity.File,
@@ -75,9 +85,11 @@ func Get(logEntity configEntity.Log, appModule configEntity.Module) *Log {
 			writer := zapcore.AddSync(logFile)
 			coreConfig = append(coreConfig, zapcore.NewCore(zapcore.NewJSONEncoder(encoderConfig), writer, zap.DebugLevel))
 		}
+
 		core := zapcore.NewTee(coreConfig...)
+
 		log = &Log{
-			logger:    zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel)),
+			logger:    zap.New(core, zap.AddCaller()),
 			AppModule: appModule,
 		}
 	})
@@ -89,30 +101,30 @@ func CustomEncodeLevel(level zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 }
 
 func (l *Log) Error(msg string) {
-	l.logger.Error(msg, l.ZapFields()...)
+	l.logger.WithOptions(zap.AddCallerSkip(1)).Error(msg, l.ZapFields()...)
 }
 
 func (l *Log) Warn(msg string) {
-	l.logger.Warn(msg, l.ZapFields()...)
+	l.logger.WithOptions(zap.AddCallerSkip(1)).Warn(msg, l.ZapFields()...)
 }
 
 func (l *Log) Info(msg string) {
-	l.logger.Info(msg, l.ZapFields()...)
+	l.logger.WithOptions(zap.AddCallerSkip(1)).Info(msg, l.ZapFields()...)
 }
 
 func (l *Log) Debug(msg string) {
-	l.logger.Debug(msg, l.ZapFields()...)
+	l.logger.WithOptions(zap.AddCallerSkip(1)).Debug(msg, l.ZapFields()...)
 }
 
 func (l *Log) ZapFields() (fields []zap.Field) {
-	fields = append(fields, zap.String("module", l.AppModule.DirectoryName()), zap.String(CorrelationIDKeyContext.String(), l.CorrelationID), zap.String("path", l.Path))
+	fields = append(fields, zap.String("module", l.AppModule.DirectoryName()), zap.String(KeyCorrelationIDContext.String(), l.CorrelationID), zap.String("path", l.Path))
 	if l.QueryString != nil {
 		fields = append(fields, zap.String("query_string", *l.QueryString))
 	}
 	return
 }
 
-func (k CorrelationIDKey) String() string {
+func (k Key) String() string {
 	return string(k)
 }
 

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -17,6 +17,8 @@ type ResponseStatus struct {
 }
 
 type Log struct {
-	Response Response `json:"response"`
-	Message  string   `json:"message"`
+	Response   Response `json:"response"`
+	Message    string   `json:"message"`
+	Caller     string   `json:"caller"`
+	StackTrace []string `json:"stack_trace"`
 }

--- a/pkg/response/status.go
+++ b/pkg/response/status.go
@@ -5,8 +5,13 @@
 package response
 
 import (
+	"fmt"
 	"net/http"
+	"os"
+	"runtime"
+	"strings"
 
+	"github.com/pkg/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -20,11 +25,14 @@ type Status struct {
 	Message string `json:"message"`
 
 	// message for engineer
-	CauseError error `json:"cause_error"`
+	CauseError error    `json:"cause_error"`
+	StackTrace []string `json:"stack_trace"`
 
 	Data   any               `json:"data"`
 	Meta   *Meta             `json:"meta"`
 	Detail map[string]string `json:"detail"`
+
+	Caller string `json:"caller"`
 }
 
 type Meta struct {
@@ -37,6 +45,111 @@ type IStatus interface {
 	IsError() bool
 	Error() string
 	MessageOrDefault() string
+}
+
+type StatusHolder struct {
+	Status *Status
+}
+
+type stackTracer interface {
+	StackTrace() errors.StackTrace
+}
+
+func getProjectDir() string {
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
+}
+
+func getErrorFiles(err error) []string {
+	dir := getProjectDir()
+
+	var files []string
+	if st, ok := err.(stackTracer); ok {
+		for _, frame := range st.StackTrace() {
+			path := fmt.Sprintf("%+s:%d", frame, frame)
+			if strings.Contains(path, dir) {
+				files = append(files, path)
+			}
+		}
+	}
+
+	return files
+}
+
+func NewStatusCode(code int) *Status {
+	_, file, line, _ := runtime.Caller(1)
+	return &Status{
+		Code:   code,
+		Caller: fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusMessage(code int, message string, err error) *Status {
+	_, file, line, _ := runtime.Caller(1)
+
+	errStack := errors.WithStack(err)
+
+	return &Status{
+		Code:       code,
+		Message:    message,
+		CauseError: errStack,
+		StackTrace: getErrorFiles(errStack),
+		Caller:     fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusData(code int, data any) *Status {
+	_, file, line, _ := runtime.Caller(1)
+	return &Status{
+		Code:   code,
+		Data:   data,
+		Caller: fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusDataMeta(code int, data any, meta *Meta) *Status {
+	_, file, line, _ := runtime.Caller(1)
+	return &Status{
+		Code:   code,
+		Data:   data,
+		Meta:   meta,
+		Caller: fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusSuccess(code int, message string, data any) *Status {
+	_, file, line, _ := runtime.Caller(1)
+	return &Status{
+		Code:    code,
+		Message: message,
+		Data:    data,
+		Caller:  fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusError(code int, err error) *Status {
+	_, file, line, _ := runtime.Caller(1)
+
+	errStack := errors.WithStack(err)
+
+	return &Status{
+		Code:       code,
+		CauseError: errStack,
+		StackTrace: getErrorFiles(errStack),
+		Caller:     fmt.Sprintf("%s:%d", file, line),
+	}
+}
+
+func NewStatusDetail(code int, message string, detail map[string]string) *Status {
+	_, file, line, _ := runtime.Caller(1)
+	return &Status{
+		Code:    code,
+		Message: message,
+		Detail:  detail,
+		Caller:  fmt.Sprintf("%s:%d", file, line),
+	}
 }
 
 func (s *Status) IsError() bool {

--- a/repositories/merchant/merchant.go
+++ b/repositories/merchant/merchant.go
@@ -18,10 +18,7 @@ import (
 func (r *MerchantRepo) MerchantInsert(ctx *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	result := r.DB.WithContext(ctx.Context).Create(merchant)
 	if result.Error != nil {
-		return false, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: result.Error,
-		}
+		return false, resPkg.NewStatusError(http.StatusInternalServerError, result.Error)
 	}
 	return true, nil
 }
@@ -30,10 +27,7 @@ func (r *MerchantRepo) MerchantUpdate(ctx *ctx.Ctx, merchant *merchantEntity.Mer
 	result := r.DB.WithContext(ctx.Context).
 		Exec("UPDATE "+merchantEntity.TABLE_NAME+" SET name = ?, updated_at = ?, updated_by = ? WHERE id = ?", merchant.Name, merchant.UpdatedAt, merchant.UpdatedBy, merchant.ID)
 	if result.Error != nil {
-		return false, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: result.Error,
-		}
+		return false, resPkg.NewStatusError(http.StatusInternalServerError, result.Error)
 	}
 	return true, nil
 }
@@ -53,20 +47,14 @@ func (r *MerchantRepo) MerchantListGetData(param *paramMerchant.MerchantListGet)
 		}
 		order, err := goku.OrdersQueryBuilder(param.Orders, orderMap)
 		if err != nil {
-			return nil, &resPkg.Status{
-				Code:       http.StatusInternalServerError,
-				CauseError: err,
-			}
+			return nil, resPkg.NewStatusError(http.StatusInternalServerError, err)
 		}
 		query = query.Order(order)
 	}
 
 	errQuery := query.Find(&merchant).Error
 	if errQuery != nil {
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return nil, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -75,10 +63,7 @@ func (r *MerchantRepo) MerchantListGetTotal(param *paramMerchant.MerchantListGet
 	query := r.MerchantListBaseQuery(param).Select("COUNT(id) AS total")
 	errQuery := query.Take(&total).Error
 	if errQuery != nil {
-		return 0, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return 0, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -95,10 +80,7 @@ func (r *MerchantRepo) MerchantListBaseQuery(param *paramMerchant.MerchantListGe
 
 func (r *MerchantRepo) MerchantDelete(c *ctx.Ctx, merchant *merchantEntity.Merchant) (ok bool, err *resPkg.Status) {
 	if err := r.DB.WithContext(c.Context).Delete(merchant).Error; err != nil {
-		return false, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: err,
-		}
+		return false, resPkg.NewStatusError(http.StatusInternalServerError, err)
 	}
 	return true, nil
 }

--- a/repositories/transaction/transaction.go
+++ b/repositories/transaction/transaction.go
@@ -34,20 +34,14 @@ func (r *TransactionRepo) MerchantOmzetGetData(param *paramTrx.MerchantOmzetGet)
 		}
 		order, err := goku.OrdersQueryBuilder(param.Orders, orderMap)
 		if err != nil {
-			return nil, &resPkg.Status{
-				Code:       http.StatusInternalServerError,
-				CauseError: err,
-			}
+			return nil, resPkg.NewStatusError(http.StatusInternalServerError, err)
 		}
 		query = query.Order(order)
 	}
 
 	errQuery := query.Find(&res).Error
 	if errQuery != nil {
-		return res, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return res, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -63,10 +57,7 @@ func (r *TransactionRepo) MerchantOmzetGetTotal(param *paramTrx.MerchantOmzetGet
 		Table("(?) AS x", query)
 	errQuery := query.Take(&total).Error
 	if errQuery != nil {
-		return 0, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return 0, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -110,20 +101,14 @@ func (r *TransactionRepo) OutletOmzetGetData(param *paramTrx.OutletOmzetGet) (re
 		}
 		order, err := goku.OrdersQueryBuilder(param.Orders, orderMap)
 		if err != nil {
-			return nil, &resPkg.Status{
-				Code:       http.StatusInternalServerError,
-				CauseError: err,
-			}
+			return nil, resPkg.NewStatusError(http.StatusInternalServerError, err)
 		}
 		query = query.Order(order)
 	}
 
 	errQuery := query.Find(&res).Error
 	if errQuery != nil {
-		return res, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return res, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -139,10 +124,7 @@ func (r *TransactionRepo) OutletOmzetGetTotal(param *paramTrx.OutletOmzetGet) (t
 		Table("(?) AS x", query)
 	errQuery := query.Take(&total).Error
 	if errQuery != nil {
-		return 0, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return 0, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }

--- a/repositories/user/user.go
+++ b/repositories/user/user.go
@@ -23,10 +23,7 @@ func (r *UserRepo) UserByUsername(ctx *ctx.Ctx, username string) (user *userEnti
 		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return nil, nil
 		}
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return nil, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return &res, nil
 }
@@ -38,10 +35,7 @@ func (r *UserRepo) MerchantIDsByUserIDGetData(userID uint64) (merchantIDs []uint
 		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return
 		}
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return nil, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }
@@ -56,10 +50,7 @@ func (r *UserRepo) OutletMerchantByUserIDGetData(userID uint64) (outlets []outle
 		if errors.Is(errQuery, gorm.ErrRecordNotFound) {
 			return
 		}
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errQuery,
-		}
+		return nil, resPkg.NewStatusError(http.StatusInternalServerError, errQuery)
 	}
 	return
 }

--- a/utils/datetime/datetime.go
+++ b/utils/datetime/datetime.go
@@ -11,11 +11,11 @@ import (
 func FromString(val string, format string, c *ctx.Ctx) (res *time.Time, err *resPkg.Status) {
 	datetime, errParse := time.Parse(format, val)
 	if errParse != nil {
-		return nil, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			Message:    c.Lang().GetByMessageID("invalid_time_format"),
-			CauseError: errParse,
-		}
+		return nil, resPkg.NewStatusMessage(
+			http.StatusInternalServerError,
+			c.Lang().GetByMessageID("invalid_time_format"),
+			errParse,
+		)
 	}
 
 	return &datetime, nil

--- a/utils/http/response.go
+++ b/utils/http/response.go
@@ -46,14 +46,18 @@ func ResponseErrorAuto(status *resPkg.Status) resPkg.Response {
 
 func LoggerFromStatus(status *resPkg.Status) resPkg.Log {
 	return resPkg.Log{
-		Response: ResponseFromStatus(status),
-		Message:  status.CauseErrorMessageOrDefault(),
+		Response:   ResponseFromStatus(status),
+		Message:    status.CauseErrorMessageOrDefault(),
+		Caller:     status.Caller,
+		StackTrace: status.StackTrace,
 	}
 }
 
 func LoggerErrorAuto(status *resPkg.Status) resPkg.Log {
 	return resPkg.Log{
-		Response: ResponseErrorAuto(status),
-		Message:  status.CauseErrorMessageOrDefault(),
+		Response:   ResponseErrorAuto(status),
+		Message:    status.CauseErrorMessageOrDefault(),
+		Caller:     status.Caller,
+		StackTrace: status.StackTrace,
 	}
 }

--- a/utils/numbers/integer.go
+++ b/utils/numbers/integer.go
@@ -14,10 +14,7 @@ import (
 func SafeConvert[T numbers.Target, S numbers.Source](val S) (result T, err *resPkg.Status) {
 	res, tmpErr := numbers.SafeConvert[T](val)
 	if tmpErr != nil {
-		return 0, &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: tmpErr,
-		}
+		return 0, resPkg.NewStatusError(http.StatusInternalServerError, tmpErr)
 	}
 	return res, nil
 }

--- a/utils/validator/validator.go
+++ b/utils/validator/validator.go
@@ -155,18 +155,16 @@ func registerOneOfOrder(v *validator.Validate, trans ut.Translator, msg string) 
 
 func (v *Validate) Struct(payloadStruct any, lang *langCtx.Lang) *resPkg.Status {
 	if payloadStruct == nil {
-		return &resPkg.Status{
-			Code:       http.StatusInternalServerError,
-			CauseError: errors.New("payloadStruct can't be nil"),
-		}
+		return resPkg.NewStatusError(
+			http.StatusInternalServerError,
+			errors.New("payloadStruct can't be nil"),
+		)
 	}
 
 	err := v.instance.Struct(payloadStruct)
 	if err != nil {
 		if _, ok := errors.AsType[*validator.InvalidValidationError](err); ok {
-			return &resPkg.Status{
-				Code: http.StatusInternalServerError,
-			}
+			return resPkg.NewStatusCode(http.StatusInternalServerError)
 		}
 		return v.ErrorFormatter(err, lang)
 	}
@@ -177,9 +175,7 @@ func (v *Validate) Struct(payloadStruct any, lang *langCtx.Lang) *resPkg.Status 
 func (v *Validate) ErrorFormatter(err error, lang *langCtx.Lang) *resPkg.Status {
 	errs, ok := errors.AsType[validator.ValidationErrors](err)
 	if !ok {
-		return &resPkg.Status{
-			Code: http.StatusBadRequest,
-		}
+		return resPkg.NewStatusCode(http.StatusBadRequest)
 	}
 
 	errMap := map[string]string{}
@@ -209,11 +205,7 @@ func (v *Validate) ErrorFormatter(err error, lang *langCtx.Lang) *resPkg.Status 
 		}
 	}
 
-	return &resPkg.Status{
-		Code:    http.StatusBadRequest,
-		Message: first,
-		Detail:  errMap,
-	}
+	return resPkg.NewStatusDetail(http.StatusBadRequest, first, errMap)
 }
 
 func (v *Validate) Translator(lang language.Tag) ut.Translator {


### PR DESCRIPTION
This change ensures that 'line' and 'stack_trace' in logs accurately point to the relevant handler, core, or repository by using runtime.Caller in factory methods and propagating it through a pointer holder in the context.