### PR TITLE
fix: prevent nil pointer dereference in logging

### DIFF
--- a/ctx/ctx.go
+++ b/ctx/ctx.go
@@ -30,7 +30,7 @@ func NewCtx(c context.Context, log *logCtx.Log) (*Ctx, *resPkg.Status) {
 	caller := fmt.Sprintf("%s:%d", file, line)
 
 	if holder, ok := c.Value(logCtx.KeyCallerHolderContext).(*logCtx.CallerHolder); ok {
-		holder.Caller = &caller
+		holder.Caller = caller
 	}
 
 	langRes, err := lang.FromContext(c)

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -81,7 +81,9 @@ func (h *GRPC) Write() {
 
 	caller := ""
 	if holder, ok := h.context.Value(KeyCallerHolderContext).(*CallerHolder); ok {
-		caller = *holder.Caller
+		if holder != nil {
+			caller = holder.Caller
+		}
 	}
 
 	if h.status.Caller != "" {

--- a/ctx/log/http.go
+++ b/ctx/log/http.go
@@ -67,7 +67,9 @@ func (h *HTTP) writeLogger(loggerRes *resPkg.Log) {
 
 	caller := ""
 	if holder, ok := h.context.Value(KeyCallerHolderContext).(*CallerHolder); ok {
-		caller = *holder.Caller
+		if holder != nil {
+			caller = holder.Caller
+		}
 	}
 
 	if loggerRes.Caller != "" {

--- a/ctx/log/log.go
+++ b/ctx/log/log.go
@@ -37,7 +37,7 @@ const (
 )
 
 type CallerHolder struct {
-	Caller *string
+	Caller string
 }
 
 var once sync.Once


### PR DESCRIPTION
- Change CallerHolder.Caller from *string to string to avoid nil pointer issues.
- Add nil checks for CallerHolder when retrieving from context in gRPC and HTTP loggers.
- Ensure logs are still written even if the process is terminated by middleware (e.g., invalid JWT) before reaching the handler.