### PR TITLE
refactor: centralize correlation ID generation logic

### DIFF
--- a/app/grpc/middleware/interceptor.go
+++ b/app/grpc/middleware/interceptor.go
@@ -18,7 +18,6 @@ import (
 	"github.com/dedyf5/resik/entities/config"
 	resPkg "github.com/dedyf5/resik/pkg/response"
 	"github.com/dedyf5/resik/utils/ratelimit"
-	"github.com/rs/xid"
 	"golang.org/x/text/language"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -67,20 +66,10 @@ func methodRoles() map[string][]Role {
 }
 
 func (i *Interceptor) logCtx(c context.Context, path string) (*context.Context, error) {
-	meta, ok := metadata.FromIncomingContext(c)
-	if !ok {
-		return i.errorMetadata()
-	}
-
-	correlationID := xid.New().String()
-	newMeta := meta.Copy()
-	newMeta.Append(logCtx.KeyCorrelationIDContext.String(), correlationID)
-	newMeta.Append(logCtx.KeyXCorrelationIDHeader.String(), correlationID)
+	correlationID, newCtx := logCtx.EnsureCorrelationID(c)
 
 	i.log.CorrelationID = correlationID
 	i.log.Path = path
-
-	newCtx := metadata.NewIncomingContext(c, newMeta)
 
 	return &newCtx, nil
 }

--- a/app/rest/fw/echo/middleware.go
+++ b/app/rest/fw/echo/middleware.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	echojwt "github.com/labstack/echo-jwt/v4"
 	"github.com/labstack/echo/v4"
-	"github.com/rs/xid"
 
 	"golang.org/x/text/language"
 )
@@ -73,12 +72,7 @@ func LoggerAndResponseFormatterMiddleware(log *logCtx.Log, appModule config.Modu
 				}
 			}
 
-			correlationID := xid.New().String()
-			c := context.WithValue(
-				r.Context(),
-				logCtx.KeyCorrelationIDContext,
-				correlationID,
-			)
+			correlationID, c := logCtx.EnsureCorrelationID(r.Context())
 
 			callerHolder := &logCtx.CallerHolder{}
 
@@ -89,8 +83,6 @@ func LoggerAndResponseFormatterMiddleware(log *logCtx.Log, appModule config.Modu
 			log.CorrelationID = correlationID
 			log.Path = r.URL.Path
 			log.QueryString = &r.URL.RawQuery
-
-			w.Header().Add(logCtx.KeyXCorrelationIDHeader.String(), correlationID)
 
 			lrw := logCtx.NewHTTP(w, appModule, c, log, time.Now(), r.Method, r.URL, contentType, r.UserAgent(), requestBody)
 

--- a/ctx/log/log.go
+++ b/ctx/log/log.go
@@ -6,6 +6,7 @@ package log
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	configEntity "github.com/dedyf5/resik/entities/config"
+	"github.com/rs/xid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/natefinch/lumberjack.v2"
@@ -32,7 +34,6 @@ type Key string
 
 const (
 	KeyCorrelationIDContext Key = "correlation_id"
-	KeyXCorrelationIDHeader Key = "X-Correlation-ID"
 	KeyCallerHolderContext  Key = "caller"
 )
 
@@ -52,6 +53,16 @@ var logLevelSeverity = map[zapcore.Level]string{
 	zapcore.DPanicLevel: "critical",
 	zapcore.PanicLevel:  "alert",
 	zapcore.FatalLevel:  "emergency",
+}
+
+func EnsureCorrelationID(ctx context.Context) (string, context.Context) {
+	if correlationID, ok := ctx.Value(KeyCorrelationIDContext).(string); ok && correlationID != "" {
+		return correlationID, ctx
+	}
+
+	correlationID := xid.New().String()
+	newCtx := context.WithValue(ctx, KeyCorrelationIDContext, correlationID)
+	return correlationID, newCtx
 }
 
 func Get(logEntity configEntity.Log, appModule configEntity.Module) *Log {


### PR DESCRIPTION
- Move correlation ID creation to logCtx.EnsureCorrelationID.
- Ensure existing correlation ID is reused if already present in context.
- Clean up unused KeyXCorrelationIDHeader constant.