### PR TITLE
feat: refactor error details to use google.rpc.errdetails

### DIFF
--- a/app/grpc/middleware/interceptor.go
+++ b/app/grpc/middleware/interceptor.go
@@ -78,7 +78,7 @@ func (i *Interceptor) logCtx(c context.Context, path string) (*context.Context, 
 func (i *Interceptor) writeLogger(c context.Context, start time.Time, fullMethod string, req any, res any, err error) (any, error) {
 	logger := logCtx.NewGRPC(c, i.log, start, fullMethod, req, res, err)
 	logger.Write()
-	return res, err
+	return res, statusUtil.GRPCErrorWithDetails(err, i.log)
 }
 
 func (i *Interceptor) langCtx(c context.Context, langDefault language.Tag) (*context.Context, *langCtx.Lang, error) {
@@ -156,13 +156,7 @@ func (i *Interceptor) Unary(c context.Context, req any, info *grpc.UnaryServerIn
 
 	res, err := handler(*tokenC, req)
 
-	res, err = i.writeLogger(c, start, info.FullMethod, req, res, err)
-
-	if err != nil {
-		return res, statusUtil.GRPCErrorWithDetails(err, i.log)
-	}
-
-	return res, err
+	return i.writeLogger(*tokenC, start, info.FullMethod, req, res, err)
 }
 
 func (i *Interceptor) RateLimit(c context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {

--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -71,6 +71,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -172,6 +175,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -264,6 +270,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -400,6 +409,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -549,6 +561,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -689,6 +704,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -803,6 +821,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -922,6 +943,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1046,6 +1070,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1204,6 +1231,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1398,6 +1428,9 @@ const docTemplaterest = `{
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1463,6 +1496,56 @@ const docTemplaterest = `{
         }
     },
     "definitions": {
+        "errdetails.BadRequest": {
+            "type": "object",
+            "properties": {
+                "field_violations": {
+                    "description": "Describes all violations in a client request.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/errdetails.BadRequest_FieldViolation"
+                    }
+                }
+            }
+        },
+        "errdetails.BadRequest_FieldViolation": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A description of why the request element is bad.",
+                    "type": "string"
+                },
+                "field": {
+                    "description": "A path that leads to a field in the request body. The value will be a\nsequence of dot-separated identifiers that identify a protocol buffer\nfield.\n\nConsider the following:\n\n\tmessage CreateContactRequest {\n\t  message EmailAddress {\n\t    enum Type {\n\t      TYPE_UNSPECIFIED = 0;\n\t      HOME = 1;\n\t      WORK = 2;\n\t    }\n\n\t    optional string email = 1;\n\t    repeated EmailType type = 2;\n\t  }\n\n\t  string full_name = 1;\n\t  repeated EmailAddress email_addresses = 2;\n\t}\n\nIn this example, in proto ` + "`" + `field` + "`" + ` could take one of the following values:\n\n  - ` + "`" + `full_name` + "`" + ` for a violation in the ` + "`" + `full_name` + "`" + ` value\n  - ` + "`" + `email_addresses[0].email` + "`" + ` for a violation in the ` + "`" + `email` + "`" + ` field of the\n    first ` + "`" + `email_addresses` + "`" + ` message\n  - ` + "`" + `email_addresses[2].type[1]` + "`" + ` for a violation in the second ` + "`" + `type` + "`" + `\n    value in the third ` + "`" + `email_addresses` + "`" + ` message.\n\nIn JSON, the same values are represented as:\n\n  - ` + "`" + `fullName` + "`" + ` for a violation in the ` + "`" + `fullName` + "`" + ` value\n  - ` + "`" + `emailAddresses[0].email` + "`" + ` for a violation in the ` + "`" + `email` + "`" + ` field of the\n    first ` + "`" + `emailAddresses` + "`" + ` message\n  - ` + "`" + `emailAddresses[2].type[1]` + "`" + ` for a violation in the second ` + "`" + `type` + "`" + `\n    value in the third ` + "`" + `emailAddresses` + "`" + ` message.",
+                    "type": "string"
+                },
+                "localized_message": {
+                    "description": "Provides a localized error message for field-level errors that is safe to\nreturn to the API consumer.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/errdetails.LocalizedMessage"
+                        }
+                    ]
+                },
+                "reason": {
+                    "description": "The reason of the field-level error. This is a constant value that\nidentifies the proximate cause of the field-level error. It should\nuniquely identify the type of the FieldViolation within the scope of the\ngoogle.rpc.ErrorInfo.domain. This should be at most 63\ncharacters and match a regular expression of ` + "`" + `[A-Z][A-Z0-9_]+[A-Z0-9]` + "`" + `,\nwhich represents UPPER_SNAKE_CASE.",
+                    "type": "string"
+                }
+            }
+        },
+        "errdetails.LocalizedMessage": {
+            "type": "object",
+            "properties": {
+                "locale": {
+                    "description": "The locale used following the specification defined at\nhttps://www.rfc-editor.org/rfc/bcp/bcp47.txt.\nExamples are: \"en-US\", \"fr-CH\", \"es-MX\"",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The localized error message in the above locale.",
+                    "type": "string"
+                }
+            }
+        },
         "request.LoginPost": {
             "type": "object",
             "required": [
@@ -1742,15 +1825,29 @@ const docTemplaterest = `{
                     "type": "string",
                     "example": "200.1"
                 },
-                "detail": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
+                "details": {},
+                "message": {
+                    "type": "string",
+                    "example": "OK"
+                }
+            }
+        },
+        "response.ResponseStatusBadRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "example": "400.1"
+                },
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/errdetails.BadRequest"
                     }
                 },
                 "message": {
                     "type": "string",
-                    "example": "OK"
+                    "example": "Bad Request"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -60,6 +60,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -161,6 +164,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -253,6 +259,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -389,6 +398,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -538,6 +550,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -678,6 +693,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -792,6 +810,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -911,6 +932,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1035,6 +1059,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1193,6 +1220,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1387,6 +1417,9 @@
                                     "properties": {
                                         "data": {
                                             "type": "object"
+                                        },
+                                        "status": {
+                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
                                         }
                                     }
                                 }
@@ -1452,6 +1485,56 @@
         }
     },
     "definitions": {
+        "errdetails.BadRequest": {
+            "type": "object",
+            "properties": {
+                "field_violations": {
+                    "description": "Describes all violations in a client request.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/errdetails.BadRequest_FieldViolation"
+                    }
+                }
+            }
+        },
+        "errdetails.BadRequest_FieldViolation": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "description": "A description of why the request element is bad.",
+                    "type": "string"
+                },
+                "field": {
+                    "description": "A path that leads to a field in the request body. The value will be a\nsequence of dot-separated identifiers that identify a protocol buffer\nfield.\n\nConsider the following:\n\n\tmessage CreateContactRequest {\n\t  message EmailAddress {\n\t    enum Type {\n\t      TYPE_UNSPECIFIED = 0;\n\t      HOME = 1;\n\t      WORK = 2;\n\t    }\n\n\t    optional string email = 1;\n\t    repeated EmailType type = 2;\n\t  }\n\n\t  string full_name = 1;\n\t  repeated EmailAddress email_addresses = 2;\n\t}\n\nIn this example, in proto `field` could take one of the following values:\n\n  - `full_name` for a violation in the `full_name` value\n  - `email_addresses[0].email` for a violation in the `email` field of the\n    first `email_addresses` message\n  - `email_addresses[2].type[1]` for a violation in the second `type`\n    value in the third `email_addresses` message.\n\nIn JSON, the same values are represented as:\n\n  - `fullName` for a violation in the `fullName` value\n  - `emailAddresses[0].email` for a violation in the `email` field of the\n    first `emailAddresses` message\n  - `emailAddresses[2].type[1]` for a violation in the second `type`\n    value in the third `emailAddresses` message.",
+                    "type": "string"
+                },
+                "localized_message": {
+                    "description": "Provides a localized error message for field-level errors that is safe to\nreturn to the API consumer.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/errdetails.LocalizedMessage"
+                        }
+                    ]
+                },
+                "reason": {
+                    "description": "The reason of the field-level error. This is a constant value that\nidentifies the proximate cause of the field-level error. It should\nuniquely identify the type of the FieldViolation within the scope of the\ngoogle.rpc.ErrorInfo.domain. This should be at most 63\ncharacters and match a regular expression of `[A-Z][A-Z0-9_]+[A-Z0-9]`,\nwhich represents UPPER_SNAKE_CASE.",
+                    "type": "string"
+                }
+            }
+        },
+        "errdetails.LocalizedMessage": {
+            "type": "object",
+            "properties": {
+                "locale": {
+                    "description": "The locale used following the specification defined at\nhttps://www.rfc-editor.org/rfc/bcp/bcp47.txt.\nExamples are: \"en-US\", \"fr-CH\", \"es-MX\"",
+                    "type": "string"
+                },
+                "message": {
+                    "description": "The localized error message in the above locale.",
+                    "type": "string"
+                }
+            }
+        },
         "request.LoginPost": {
             "type": "object",
             "required": [
@@ -1731,15 +1814,29 @@
                     "type": "string",
                     "example": "200.1"
                 },
-                "detail": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "type": "string"
+                "details": {},
+                "message": {
+                    "type": "string",
+                    "example": "OK"
+                }
+            }
+        },
+        "response.ResponseStatusBadRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string",
+                    "example": "400.1"
+                },
+                "details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/errdetails.BadRequest"
                     }
                 },
                 "message": {
                     "type": "string",
-                    "example": "OK"
+                    "example": "Bad Request"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -1,4 +1,64 @@
 definitions:
+  errdetails.BadRequest:
+    properties:
+      field_violations:
+        description: Describes all violations in a client request.
+        items:
+          $ref: '#/definitions/errdetails.BadRequest_FieldViolation'
+        type: array
+    type: object
+  errdetails.BadRequest_FieldViolation:
+    properties:
+      description:
+        description: A description of why the request element is bad.
+        type: string
+      field:
+        description: "A path that leads to a field in the request body. The value
+          will be a\nsequence of dot-separated identifiers that identify a protocol
+          buffer\nfield.\n\nConsider the following:\n\n\tmessage CreateContactRequest
+          {\n\t  message EmailAddress {\n\t    enum Type {\n\t      TYPE_UNSPECIFIED
+          = 0;\n\t      HOME = 1;\n\t      WORK = 2;\n\t    }\n\n\t    optional string
+          email = 1;\n\t    repeated EmailType type = 2;\n\t  }\n\n\t  string full_name
+          = 1;\n\t  repeated EmailAddress email_addresses = 2;\n\t}\n\nIn this example,
+          in proto `field` could take one of the following values:\n\n  - `full_name`
+          for a violation in the `full_name` value\n  - `email_addresses[0].email`
+          for a violation in the `email` field of the\n    first `email_addresses`
+          message\n  - `email_addresses[2].type[1]` for a violation in the second
+          `type`\n    value in the third `email_addresses` message.\n\nIn JSON, the
+          same values are represented as:\n\n  - `fullName` for a violation in the
+          `fullName` value\n  - `emailAddresses[0].email` for a violation in the `email`
+          field of the\n    first `emailAddresses` message\n  - `emailAddresses[2].type[1]`
+          for a violation in the second `type`\n    value in the third `emailAddresses`
+          message."
+        type: string
+      localized_message:
+        allOf:
+        - $ref: '#/definitions/errdetails.LocalizedMessage'
+        description: |-
+          Provides a localized error message for field-level errors that is safe to
+          return to the API consumer.
+      reason:
+        description: |-
+          The reason of the field-level error. This is a constant value that
+          identifies the proximate cause of the field-level error. It should
+          uniquely identify the type of the FieldViolation within the scope of the
+          google.rpc.ErrorInfo.domain. This should be at most 63
+          characters and match a regular expression of `[A-Z][A-Z0-9_]+[A-Z0-9]`,
+          which represents UPPER_SNAKE_CASE.
+        type: string
+    type: object
+  errdetails.LocalizedMessage:
+    properties:
+      locale:
+        description: |-
+          The locale used following the specification defined at
+          https://www.rfc-editor.org/rfc/bcp/bcp47.txt.
+          Examples are: "en-US", "fr-CH", "es-MX"
+        type: string
+      message:
+        description: The localized error message in the above locale.
+        type: string
+    type: object
   request.LoginPost:
     properties:
       password:
@@ -194,12 +254,22 @@ definitions:
       code:
         example: "200.1"
         type: string
-      detail:
-        additionalProperties:
-          type: string
-        type: object
+      details: {}
       message:
         example: OK
+        type: string
+    type: object
+  response.ResponseStatusBadRequest:
+    properties:
+      code:
+        example: "400.1"
+        type: string
+      details:
+        items:
+          $ref: '#/definitions/errdetails.BadRequest'
+        type: array
+      message:
+        example: Bad Request
         type: string
     type: object
   response.UserCredential:
@@ -247,6 +317,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "429":
           description: Too Many Requests
@@ -302,6 +374,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "503":
           description: Service Unavailable
@@ -354,6 +428,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -430,6 +506,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -510,6 +588,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -574,6 +654,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -650,6 +732,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -716,6 +800,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "429":
           description: Too Many Requests
@@ -780,6 +866,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "500":
           description: Internal Server Error
@@ -878,6 +966,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized
@@ -994,6 +1084,8 @@ paths:
             - properties:
                 data:
                   type: object
+                status:
+                  $ref: '#/definitions/response.ResponseStatusBadRequest'
               type: object
         "401":
           description: Unauthorized

--- a/app/rest/fw/echo/binder.go
+++ b/app/rest/fw/echo/binder.go
@@ -5,7 +5,6 @@
 package echo
 
 import (
-	"net/http"
 	"reflect"
 	"regexp"
 	"strings"
@@ -150,18 +149,16 @@ func (b *bind) ParamValidator(c echo.Context, i any) error {
 				continue
 			}
 
-			msg := lang.GetByTemplateData("validation_type_message", common.Map{
-				"field":    fn,
-				"expected": ft,
-				"actual":   "string",
-			})
-			return resPkg.NewStatusDetail(
-				http.StatusBadRequest,
-				msg,
-				map[string]string{
-					fn: msg,
+			msg := lang.GetByTemplateData(
+				"validation_type_message",
+				common.Map{
+					"field":    fn,
+					"expected": ft,
+					"actual":   "string",
 				},
 			)
+
+			return resPkg.NewStatusBadRequest(fn, msg)
 		}
 
 		return nil
@@ -194,14 +191,16 @@ func (b *bind) JSONErrorFormatter(c echo.Context, err error) error {
 	gotReg := regexp.MustCompile(`got\=(.*?),`)
 	gots := gotReg.FindStringSubmatch(err.Error())
 	if len(fields) > 1 && len(expecteds) > 1 && len(gots) > 1 {
-		errMap := map[string]string{}
 		field := fields[1]
-		errMap[field] = lang.GetByTemplateData("validation_type_message", common.Map{
-			"field":    field,
-			"expected": expecteds[1],
-			"actual":   gots[1],
-		})
-		return resPkg.NewStatusDetail(http.StatusBadRequest, errMap[field], errMap)
+		message := lang.GetByTemplateData(
+			"validation_type_message",
+			common.Map{
+				"field":    field,
+				"expected": expecteds[1],
+				"actual":   gots[1],
+			},
+		)
+		return resPkg.NewStatusBadRequest(field, message)
 	}
 
 	return nil

--- a/app/rest/handler/general/handler.go
+++ b/app/rest/handler/general/handler.go
@@ -38,7 +38,7 @@ func New(config config.Config, log *logCtx.Log, fw echoFW.IEcho) *Handler {
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=resAppCore.App}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
 // @Router		/ [get]

--- a/app/rest/handler/health/handler.go
+++ b/app/rest/handler/health/handler.go
@@ -38,7 +38,7 @@ func New(log *logCtx.Log, fw echoFW.IEcho, hs healthCore.IService) *HealthHandle
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=response.HealthHealthz}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     503 {object}	resPkg.Response{data=nil}
 // @Router		/healthz [get]
 func (h *HealthHandler) HealthHealthzGet(echoCtx echo.Context) error {
@@ -71,7 +71,7 @@ func (h *HealthHandler) HealthHealthzGet(echoCtx echo.Context) error {
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=response.HealthReadyz}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
 // @Failure     503 {object}	resPkg.Response{data=nil}

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -41,7 +41,7 @@ func New(log *logCtx.Log, fw echoFW.IEcho, merchantService merchantCore.IService
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqMerchantCore.MerchantPost true "Payload"
 // @Success		201	{object}	resPkg.Response{data=resMerchantCore.MerchantUpsert}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
@@ -90,7 +90,7 @@ func (h *Handler) MerchantPost(echoCtx echo.Context) error {
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqMerchantCore.MerchantPut true "Payload"
 // @Success		200	{object}	resPkg.Response{data=resMerchantCore.MerchantUpsert}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
@@ -142,7 +142,7 @@ func (h *Handler) MerchantPut(echoCtx echo.Context) error {
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqMerchantCore.MerchantListGet true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=[]resMerchantCore.MerchantList}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     404 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
@@ -194,7 +194,7 @@ func (h *Handler) MerchantListGet(echoCtx echo.Context) error {
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqMerchantCore.MerchantDelete true "Query Param"
 // @Success		204	{object}	nil
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}

--- a/app/rest/handler/transaction/handler.go
+++ b/app/rest/handler/transaction/handler.go
@@ -49,7 +49,7 @@ func New(fw echoFW.IEcho, log *logCtx.Log, trxService trxService.IService, confi
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.MerchantOmzetGet true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=[]resTrxCore.MerchantOmzet}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
@@ -102,7 +102,7 @@ func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.OutletOmzetGet true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=[]resTrxCore.OutletOmzet}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     429 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}

--- a/app/rest/handler/user/handler.go
+++ b/app/rest/handler/user/handler.go
@@ -41,7 +41,7 @@ func New(fw echoFW.IEcho, log *logCtx.Log, userService userService.IService) *Ha
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqUserCore.LoginPost true "Payload"
 // @Success		200	{object}	resPkg.Response{data=resUserCore.UserCredential}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     401 {object}	resPkg.Response{data=nil}
 // @Failure     500 {object}	resPkg.Response{data=nil}
 // @Router		/login [post]
@@ -80,7 +80,7 @@ func (h *Handler) LoginPost(echoCtx echo.Context) error {
 // @Security BearerAuth
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Success		200	{object}	resPkg.Response{data=resUserCore.UserCredential}
-// @Failure     400 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
 // @Failure     500 {object}	resPkg.Response{data=nil}
 // @Router		/token-refresh [get]
 func (h *Handler) TokenRefreshGet(echoCtx echo.Context) error {

--- a/ctx/lang/lang.go
+++ b/ctx/lang/lang.go
@@ -133,13 +133,7 @@ func GetLanguageAvailable(lang string) (*language.Tag, *resPkg.Status) {
 func LanguageIsAvailable(lang string) (bool, *resPkg.Status) {
 	if lang == "" {
 		msg := "lang is required"
-		return false, resPkg.NewStatusDetail(
-			http.StatusBadRequest,
-			msg,
-			map[string]string{
-				ContextKey.String(): msg,
-			},
-		)
+		return false, resPkg.NewStatusBadRequest(ContextKey.String(), msg)
 	}
 	langCodes := make([]string, 0, cap(Available))
 	for _, v := range Available {
@@ -147,13 +141,7 @@ func LanguageIsAvailable(lang string) (bool, *resPkg.Status) {
 	}
 	if !slices.Contains(langCodes, lang) {
 		msg := fmt.Sprintf("lang must be one of [%s]", strings.Join(langCodes, ", "))
-		return false, resPkg.NewStatusDetail(
-			http.StatusBadRequest,
-			msg,
-			map[string]string{
-				ContextKey.String(): msg,
-			},
-		)
+		return false, resPkg.NewStatusBadRequest(ContextKey.String(), msg)
 	}
 	return true, nil
 }

--- a/ctx/log/grpc.go
+++ b/ctx/log/grpc.go
@@ -135,9 +135,9 @@ func (h *GRPC) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		}
 	}
 
-	if len(h.status.Detail) > 0 {
-		if err := enc.AddReflected("detail", h.status.Detail); err != nil {
-			enc.AddString("detail_error", err.Error())
+	if len(h.status.Details) > 0 {
+		if err := enc.AddReflected("details", h.status.Details); err != nil {
+			enc.AddString("details_error", err.Error())
 		}
 	}
 

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -4,6 +4,10 @@
 
 package response
 
+import (
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+)
+
 type Response struct {
 	Status ResponseStatus `json:"status"`
 	Data   any            `json:"data,omitempty"`
@@ -11,9 +15,15 @@ type Response struct {
 }
 
 type ResponseStatus struct {
-	Code    string            `json:"code" example:"200.1"`
-	Message string            `json:"message" example:"OK"`
-	Detail  map[string]string `json:"detail,omitempty"`
+	Code    string `json:"code" example:"200.1"`
+	Message string `json:"message" example:"OK"`
+	Details any    `json:"details,omitempty"`
+}
+
+type ResponseStatusBadRequest struct {
+	Code    string                   `json:"code" example:"400.1"`
+	Message string                   `json:"message" example:"Bad Request"`
+	Details []*errdetails.BadRequest `json:"details,omitempty"`
 }
 
 type Log struct {

--- a/pkg/response/status.go
+++ b/pkg/response/status.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/protoadapt"
 )
 
 // use this Status to wrap error across all apps including non http app
@@ -28,9 +30,9 @@ type Status struct {
 	CauseError error    `json:"cause_error"`
 	StackTrace []string `json:"stack_trace"`
 
-	Data   any               `json:"data"`
-	Meta   *Meta             `json:"meta"`
-	Detail map[string]string `json:"detail"`
+	Data    any                    `json:"data"`
+	Meta    *Meta                  `json:"meta"`
+	Details []protoadapt.MessageV1 `json:"details"`
 
 	Caller string `json:"caller"`
 }
@@ -160,14 +162,39 @@ func NewStatusError(code int, err error) *Status {
 	}
 }
 
-func NewStatusDetail(code int, message string, detail map[string]string) *Status {
+func NewStatusDetails(code int, message string, details ...protoadapt.MessageV1) *Status {
 	_, file, line, _ := runtime.Caller(1)
 	return &Status{
 		Code:    code,
 		Message: message,
-		Detail:  detail,
+		Details: details,
 		Caller:  fmt.Sprintf("%s:%d", file, line),
 	}
+}
+
+func NewStatusBadRequest(field, message string) *Status {
+	return NewStatusDetails(
+		http.StatusBadRequest,
+		message,
+		&errdetails.BadRequest{
+			FieldViolations: []*errdetails.BadRequest_FieldViolation{
+				{
+					Field:       field,
+					Description: message,
+				},
+			},
+		},
+	)
+}
+
+func (s *Status) BadRequests() []*errdetails.BadRequest {
+	badReqs := make([]*errdetails.BadRequest, 0, len(s.Details))
+	for _, detail := range s.Details {
+		if badReq, ok := detail.(*errdetails.BadRequest); ok {
+			badReqs = append(badReqs, badReq)
+		}
+	}
+	return badReqs
 }
 
 func (s *Status) IsError() bool {

--- a/utils/http/response.go
+++ b/utils/http/response.go
@@ -39,7 +39,7 @@ func ResponseErrorAuto(status *resPkg.Status) resPkg.Response {
 		Status: resPkg.ResponseStatus{
 			Code:    fmt.Sprintf("%d.1", status.Code),
 			Message: status.MessageOrDefault(),
-			Detail:  status.Detail,
+			Details: status.BadRequests(),
 		},
 	}
 

--- a/utils/status/status.go
+++ b/utils/status/status.go
@@ -9,7 +9,6 @@ import (
 
 	logCtx "github.com/dedyf5/resik/ctx/log"
 	resPkg "github.com/dedyf5/resik/pkg/response"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 func GRPCErrorWithDetails(err error, logCtx *logCtx.Log) error {
@@ -22,23 +21,11 @@ func GRPCErrorWithDetails(err error, logCtx *logCtx.Log) error {
 		return err
 	}
 
-	if !statusPkg.IsError() || len(statusPkg.Detail) == 0 {
+	if !statusPkg.IsError() || len(statusPkg.Details) == 0 {
 		return err
 	}
 
-	fieldViolations := make([]*errdetails.BadRequest_FieldViolation, 0, len(statusPkg.Detail))
-	for field, description := range statusPkg.Detail {
-		fieldViolations = append(fieldViolations, &errdetails.BadRequest_FieldViolation{
-			Field:       field,
-			Description: description,
-		})
-	}
-
-	badRequest := errdetails.BadRequest{
-		FieldViolations: fieldViolations,
-	}
-
-	statusErr, unexpectedErr := statusPkg.GRPCStatus().WithDetails(&badRequest)
+	statusErr, unexpectedErr := statusPkg.GRPCStatus().WithDetails(statusPkg.Details...)
 	if unexpectedErr != nil {
 		logCtx.Error("failed to add details to status: " + unexpectedErr.Error())
 		return err

--- a/utils/validator/validator.go
+++ b/utils/validator/validator.go
@@ -25,6 +25,7 @@ import (
 	idTrans "github.com/go-playground/validator/v10/translations/id"
 	jaTrans "github.com/go-playground/validator/v10/translations/ja"
 	"golang.org/x/text/language"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 )
 
 //go:generate mockgen -source validator.go -package mock -destination ./mock/validator.go
@@ -178,7 +179,7 @@ func (v *Validate) ErrorFormatter(err error, lang *langCtx.Lang) *resPkg.Status 
 		return resPkg.NewStatusCode(http.StatusBadRequest)
 	}
 
-	errMap := map[string]string{}
+	volations := []*errdetails.BadRequest_FieldViolation{}
 
 	regexKey := regexp.MustCompile(`^[^.]*.`)
 	regexDate := regexp.MustCompile("2006-01-02")
@@ -199,13 +200,21 @@ func (v *Validate) ErrorFormatter(err error, lang *langCtx.Lang) *resPkg.Status 
 			value = regexZone.ReplaceAllString(value, ".SSSZZ")
 		}
 
-		errMap[field] = value
+		volations = append(volations, &errdetails.BadRequest_FieldViolation{
+			Field:       field,
+			Description: value,
+		})
+
 		if k == 0 {
 			first = value
 		}
 	}
 
-	return resPkg.NewStatusDetail(http.StatusBadRequest, first, errMap)
+	badRequest := &errdetails.BadRequest{
+		FieldViolations: volations,
+	}
+
+	return resPkg.NewStatusDetails(http.StatusBadRequest, first, badRequest)
 }
 
 func (v *Validate) Translator(lang language.Tag) ut.Translator {


### PR DESCRIPTION
- Replace map[string]string error details with errdetails.BadRequest.
- Update gRPC and REST to support structured error details.
- Implement NewStatusBadRequest and NewStatusDetails in response package.
- Sync Swagger definitions with the new structured error format (status code 400).