### PR TITLE
refactor(docs): use specific response types for precise Swagger schemas

### DIFF
--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -1412,6 +1412,7 @@ const docTemplaterest = `{
     },
     "securityDefinitions": {
         "BearerAuth": {
+            "description": "Type \"Bearer \" followed by a space and then your API token.",
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -46,7 +46,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -62,58 +62,19 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -150,7 +111,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -166,40 +127,19 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -245,7 +185,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -261,58 +201,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -381,7 +288,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -400,94 +307,31 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -536,7 +380,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -552,76 +396,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -679,7 +472,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -695,76 +488,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -812,76 +554,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -918,7 +609,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -934,76 +625,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1045,7 +685,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -1061,40 +701,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1203,7 +828,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -1222,76 +847,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1400,7 +974,7 @@ const docTemplaterest = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -1419,76 +993,25 @@ const docTemplaterest = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1646,7 +1169,7 @@ const docTemplaterest = `{
             "properties": {
                 "accessed_at": {
                     "type": "string",
-                    "example": "2025-06-14 16:42:00"
+                    "example": "2026-04-17T01:30:08Z"
                 }
             }
         },
@@ -1655,7 +1178,7 @@ const docTemplaterest = `{
             "properties": {
                 "accessed_at": {
                     "type": "string",
-                    "example": "2025-06-14 16:42:00"
+                    "example": "2026-04-17T01:30:08Z"
                 },
                 "checks": {
                     "type": "array",
@@ -1765,15 +1288,19 @@ const docTemplaterest = `{
                 }
             }
         },
-        "response.Response": {
+        "response.ResponseBadRequest": {
             "type": "object",
             "properties": {
-                "data": {},
-                "meta": {
-                    "$ref": "#/definitions/response.ResponseMeta"
-                },
                 "status": {
-                    "$ref": "#/definitions/response.ResponseStatus"
+                    "$ref": "#/definitions/response.ResponseStatusBadRequest"
+                }
+            }
+        },
+        "response.ResponseErrorWithoutDetails": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
                 }
             }
         },
@@ -1818,20 +1345,6 @@ const docTemplaterest = `{
                 }
             }
         },
-        "response.ResponseStatus": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "example": "200.1"
-                },
-                "details": {},
-                "message": {
-                    "type": "string",
-                    "example": "OK"
-                }
-            }
-        },
         "response.ResponseStatusBadRequest": {
             "type": "object",
             "properties": {
@@ -1848,6 +1361,38 @@ const docTemplaterest = `{
                 "message": {
                     "type": "string",
                     "example": "Bad Request"
+                }
+            }
+        },
+        "response.ResponseStatusWithoutDetails": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.ResponseSuccess": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
+                }
+            }
+        },
+        "response.ResponseSuccessWithMeta": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "meta": {
+                    "$ref": "#/definitions/response.ResponseMeta"
+                },
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -1401,6 +1401,7 @@
     },
     "securityDefinitions": {
         "BearerAuth": {
+            "description": "Type \"Bearer \" followed by a space and then your API token.",
             "type": "apiKey",
             "name": "Authorization",
             "in": "header"

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -35,7 +35,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -51,58 +51,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -139,7 +100,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -155,40 +116,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -234,7 +174,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -250,58 +190,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -370,7 +277,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -389,94 +296,31 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -525,7 +369,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -541,76 +385,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -668,7 +461,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -684,76 +477,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -801,76 +543,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -907,7 +598,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -923,76 +614,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "503": {
                         "description": "Service Unavailable",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1034,7 +674,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccess"
                                 },
                                 {
                                     "type": "object",
@@ -1050,40 +690,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
+                        }
+                    },
+                    "429": {
+                        "description": "Too Many Requests",
+                        "schema": {
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1192,7 +817,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -1211,76 +836,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1389,7 +963,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/response.ResponseSuccessWithMeta"
                                 },
                                 {
                                     "type": "object",
@@ -1408,76 +982,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        },
-                                        "status": {
-                                            "$ref": "#/definitions/response.ResponseStatusBadRequest"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseBadRequest"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "allOf": [
-                                {
-                                    "$ref": "#/definitions/response.Response"
-                                },
-                                {
-                                    "type": "object",
-                                    "properties": {
-                                        "data": {
-                                            "type": "object"
-                                        }
-                                    }
-                                }
-                            ]
+                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     }
                 }
@@ -1635,7 +1158,7 @@
             "properties": {
                 "accessed_at": {
                     "type": "string",
-                    "example": "2025-06-14 16:42:00"
+                    "example": "2026-04-17T01:30:08Z"
                 }
             }
         },
@@ -1644,7 +1167,7 @@
             "properties": {
                 "accessed_at": {
                     "type": "string",
-                    "example": "2025-06-14 16:42:00"
+                    "example": "2026-04-17T01:30:08Z"
                 },
                 "checks": {
                     "type": "array",
@@ -1754,15 +1277,19 @@
                 }
             }
         },
-        "response.Response": {
+        "response.ResponseBadRequest": {
             "type": "object",
             "properties": {
-                "data": {},
-                "meta": {
-                    "$ref": "#/definitions/response.ResponseMeta"
-                },
                 "status": {
-                    "$ref": "#/definitions/response.ResponseStatus"
+                    "$ref": "#/definitions/response.ResponseStatusBadRequest"
+                }
+            }
+        },
+        "response.ResponseErrorWithoutDetails": {
+            "type": "object",
+            "properties": {
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
                 }
             }
         },
@@ -1807,20 +1334,6 @@
                 }
             }
         },
-        "response.ResponseStatus": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string",
-                    "example": "200.1"
-                },
-                "details": {},
-                "message": {
-                    "type": "string",
-                    "example": "OK"
-                }
-            }
-        },
         "response.ResponseStatusBadRequest": {
             "type": "object",
             "properties": {
@@ -1837,6 +1350,38 @@
                 "message": {
                     "type": "string",
                     "example": "Bad Request"
+                }
+            }
+        },
+        "response.ResponseStatusWithoutDetails": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "response.ResponseSuccess": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
+                }
+            }
+        },
+        "response.ResponseSuccessWithMeta": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "meta": {
+                    "$ref": "#/definitions/response.ResponseMeta"
+                },
+                "status": {
+                    "$ref": "#/definitions/response.ResponseStatusWithoutDetails"
                 }
             }
         },

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -129,13 +129,13 @@ definitions:
   response.HealthHealthz:
     properties:
       accessed_at:
-        example: "2025-06-14 16:42:00"
+        example: "2026-04-17T01:30:08Z"
         type: string
     type: object
   response.HealthReadyz:
     properties:
       accessed_at:
-        example: "2025-06-14 16:42:00"
+        example: "2026-04-17T01:30:08Z"
         type: string
       checks:
         items:
@@ -212,13 +212,15 @@ definitions:
         example: "2023-11-22"
         type: string
     type: object
-  response.Response:
+  response.ResponseBadRequest:
     properties:
-      data: {}
-      meta:
-        $ref: '#/definitions/response.ResponseMeta'
       status:
-        $ref: '#/definitions/response.ResponseStatus'
+        $ref: '#/definitions/response.ResponseStatusBadRequest'
+    type: object
+  response.ResponseErrorWithoutDetails:
+    properties:
+      status:
+        $ref: '#/definitions/response.ResponseStatusWithoutDetails'
     type: object
   response.ResponseMeta:
     properties:
@@ -249,16 +251,6 @@ definitions:
         example: 2
         type: integer
     type: object
-  response.ResponseStatus:
-    properties:
-      code:
-        example: "200.1"
-        type: string
-      details: {}
-      message:
-        example: OK
-        type: string
-    type: object
   response.ResponseStatusBadRequest:
     properties:
       code:
@@ -271,6 +263,27 @@ definitions:
       message:
         example: Bad Request
         type: string
+    type: object
+  response.ResponseStatusWithoutDetails:
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+    type: object
+  response.ResponseSuccess:
+    properties:
+      data: {}
+      status:
+        $ref: '#/definitions/response.ResponseStatusWithoutDetails'
+    type: object
+  response.ResponseSuccessWithMeta:
+    properties:
+      data: {}
+      meta:
+        $ref: '#/definitions/response.ResponseMeta'
+      status:
+        $ref: '#/definitions/response.ResponseStatusWithoutDetails'
     type: object
   response.UserCredential:
     properties:
@@ -304,7 +317,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.App'
@@ -312,32 +325,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       summary: Get Home
       tags:
       - home
@@ -361,7 +357,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.HealthHealthz'
@@ -369,23 +365,15 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "503":
           description: Service Unavailable
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       summary: Liveness check
       tags:
       - health
@@ -415,7 +403,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.UserCredential'
@@ -423,32 +411,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       summary: Login
       tags:
       - user
@@ -491,7 +466,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccessWithMeta'
             - properties:
                 data:
                   items:
@@ -501,50 +476,23 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "404":
           description: Not Found
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Merchant List
@@ -575,7 +523,7 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.MerchantUpsert'
@@ -583,41 +531,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Create Merchant
@@ -649,41 +575,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Update Merchant
@@ -719,7 +623,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.MerchantUpsert'
@@ -727,41 +631,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Update Merchant
@@ -787,7 +669,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.HealthReadyz'
@@ -795,41 +677,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "503":
           description: Service Unavailable
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       summary: Readiness check
       tags:
       - health
@@ -853,7 +713,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccess'
             - properties:
                 data:
                   $ref: '#/definitions/response.UserCredential'
@@ -861,23 +721,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
+        "429":
+          description: Too Many Requests
+          schema:
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Token Refresh
@@ -951,7 +807,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccessWithMeta'
             - properties:
                 data:
                   items:
@@ -961,41 +817,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Get Merchant Omzet
@@ -1069,7 +903,7 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/response.ResponseSuccessWithMeta'
             - properties:
                 data:
                   items:
@@ -1079,41 +913,19 @@ paths:
         "400":
           description: Bad Request
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-                status:
-                  $ref: '#/definitions/response.ResponseStatusBadRequest'
-              type: object
+            $ref: '#/definitions/response.ResponseBadRequest'
         "401":
           description: Unauthorized
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "500":
           description: Internal Server Error
           schema:
-            allOf:
-            - $ref: '#/definitions/response.Response'
-            - properties:
-                data:
-                  type: object
-              type: object
+            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
       security:
       - BearerAuth: []
       summary: Get Outlet Omzet

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -933,6 +933,7 @@ paths:
       - transaction
 securityDefinitions:
   BearerAuth:
+    description: Type "Bearer " followed by a space and then your API token.
     in: header
     name: Authorization
     type: apiKey

--- a/app/rest/handler/general/handler.go
+++ b/app/rest/handler/general/handler.go
@@ -37,10 +37,10 @@ func New(config config.Config, log *logCtx.Log, fw echoFW.IEcho) *Handler {
 // @Accept json
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=resAppCore.App}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=resAppCore.App}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/ [get]
 func (h *Handler) Home(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)

--- a/app/rest/handler/health/handler.go
+++ b/app/rest/handler/health/handler.go
@@ -37,9 +37,10 @@ func New(log *logCtx.Log, fw echoFW.IEcho, hs healthCore.IService) *HealthHandle
 // @Accept json
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=response.HealthHealthz}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     503 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=response.HealthHealthz}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     503 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/healthz [get]
 func (h *HealthHandler) HealthHealthzGet(echoCtx echo.Context) error {
 	var payload commonEntity.Request
@@ -70,11 +71,11 @@ func (h *HealthHandler) HealthHealthzGet(echoCtx echo.Context) error {
 // @Accept json
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=response.HealthReadyz}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
-// @Failure     503 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=response.HealthReadyz}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     503 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/readyz [get]
 func (h *HealthHandler) HealthReadyzGet(echoCtx echo.Context) error {
 	var payload commonEntity.Request

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -40,11 +40,11 @@ func New(log *logCtx.Log, fw echoFW.IEcho, merchantService merchantCore.IService
 // @Security BearerAuth
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqMerchantCore.MerchantPost true "Payload"
-// @Success		201	{object}	resPkg.Response{data=resMerchantCore.MerchantUpsert}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		201	{object}	resPkg.ResponseSuccess{data=resMerchantCore.MerchantUpsert}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/merchant [post]
 func (h *Handler) MerchantPost(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)
@@ -89,11 +89,11 @@ func (h *Handler) MerchantPost(echoCtx echo.Context) error {
 // @Param       id path int true "Merchant ID"
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqMerchantCore.MerchantPut true "Payload"
-// @Success		200	{object}	resPkg.Response{data=resMerchantCore.MerchantUpsert}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=resMerchantCore.MerchantUpsert}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/merchant/{id} [put]
 func (h *Handler) MerchantPut(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)
@@ -141,12 +141,12 @@ func (h *Handler) MerchantPut(echoCtx echo.Context) error {
 // @Security BearerAuth
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqMerchantCore.MerchantListGet true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=[]resMerchantCore.MerchantList}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     404 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccessWithMeta{data=[]resMerchantCore.MerchantList}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     404 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/merchant [get]
 func (h *Handler) MerchantListGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)
@@ -194,10 +194,10 @@ func (h *Handler) MerchantListGet(echoCtx echo.Context) error {
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqMerchantCore.MerchantDelete true "Query Param"
 // @Success		204	{object}	nil
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/merchant/{id} [delete]
 func (h *Handler) MerchantDelete(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)

--- a/app/rest/handler/transaction/handler.go
+++ b/app/rest/handler/transaction/handler.go
@@ -48,11 +48,11 @@ func New(fw echoFW.IEcho, log *logCtx.Log, trxService trxService.IService, confi
 // @Param       merchant_id path int true "Merchant ID"
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.MerchantOmzetGet true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=[]resTrxCore.MerchantOmzet}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccessWithMeta{data=[]resTrxCore.MerchantOmzet}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/transaction/merchant/{merchant_id}/omzet [get]
 func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)
@@ -101,11 +101,11 @@ func (h *Handler) MerchantOmzetGet(echoCtx echo.Context) error {
 // @Param       outlet_id path int true "Outlet ID"
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       parameter query reqTrxCore.OutletOmzetGet true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=[]resTrxCore.OutletOmzet}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     429 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccessWithMeta{data=[]resTrxCore.OutletOmzet}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/transaction/outlet/{outlet_id}/omzet [get]
 func (h *Handler) OutletOmzetGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)

--- a/app/rest/handler/user/handler.go
+++ b/app/rest/handler/user/handler.go
@@ -40,10 +40,11 @@ func New(fw echoFW.IEcho, log *logCtx.Log, userService userService.IService) *Ha
 // @Produce json
 // @Param       parameter query commonEntity.Request true "Query Param"
 // @Param       payload body reqUserCore.LoginPost true "Payload"
-// @Success		200	{object}	resPkg.Response{data=resUserCore.UserCredential}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     401 {object}	resPkg.Response{data=nil}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=resUserCore.UserCredential}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/login [post]
 func (h *Handler) LoginPost(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)
@@ -79,9 +80,11 @@ func (h *Handler) LoginPost(echoCtx echo.Context) error {
 // @Produce json
 // @Security BearerAuth
 // @Param       parameter query commonEntity.Request true "Query Param"
-// @Success		200	{object}	resPkg.Response{data=resUserCore.UserCredential}
-// @Failure     400 {object}	resPkg.Response{data=nil,status=resPkg.ResponseStatusBadRequest}
-// @Failure     500 {object}	resPkg.Response{data=nil}
+// @Success		200	{object}	resPkg.ResponseSuccess{data=resUserCore.UserCredential}
+// @Failure     400 {object}	resPkg.ResponseBadRequest
+// @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
+// @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/token-refresh [get]
 func (h *Handler) TokenRefreshGet(echoCtx echo.Context) error {
 	ctx, err := ctx.NewCtx(echoCtx.Request().Context(), h.log)

--- a/app/rest/main.go
+++ b/app/rest/main.go
@@ -17,9 +17,10 @@ var app *bootstrap.App
 var cleanup func()
 var err error
 
-// @securityDefinitions.apikey BearerAuth
-// @in header
-// @name Authorization
+// @securityDefinitions.apikey	BearerAuth
+// @in 							header
+// @name 						Authorization
+// @description					Type "Bearer " followed by a space and then your API token.
 func Run() {
 	c, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()

--- a/core/health/response/healthz.pb.go
+++ b/core/health/response/healthz.pb.go
@@ -29,7 +29,7 @@ type HealthHealthz struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	AccessedAt string `protobuf:"bytes,1,opt,name=accessed_at,json=accessedAt,proto3" json:"accessed_at" example:"2025-06-14 16:42:00"`  
+	AccessedAt string `protobuf:"bytes,1,opt,name=accessed_at,json=accessedAt,proto3" json:"accessed_at" example:"2026-04-17T01:30:08Z"`  
 }
 
 func (x *HealthHealthz) Reset() {

--- a/core/health/response/healthz.proto
+++ b/core/health/response/healthz.proto
@@ -8,5 +8,5 @@ package response;
 option go_package = "github.com/dedyf5/resik/core/health/response";
 
 message HealthHealthz {
-    string accessed_at = 1; // @gotags: json:"accessed_at" example:"2025-06-14 16:42:00"
+    string accessed_at = 1; // @gotags: json:"accessed_at" example:"2026-04-17T01:30:08Z"
 }

--- a/core/health/response/readyz.pb.go
+++ b/core/health/response/readyz.pb.go
@@ -31,7 +31,7 @@ type HealthReadyz struct {
 
 	OverallStatus string               `protobuf:"bytes,1,opt,name=overall_status,json=overallStatus,proto3" json:"overall_status" example:"UP"`  
 	Checks        []*HealthReadyzCheck `protobuf:"bytes,2,rep,name=checks,proto3" json:"checks"`                                     
-	AccessedAt    string               `protobuf:"bytes,3,opt,name=accessed_at,json=accessedAt,proto3" json:"accessed_at" example:"2025-06-14 16:42:00"`           
+	AccessedAt    string               `protobuf:"bytes,3,opt,name=accessed_at,json=accessedAt,proto3" json:"accessed_at" example:"2026-04-17T01:30:08Z"`           
 }
 
 func (x *HealthReadyz) Reset() {

--- a/core/health/response/readyz.proto
+++ b/core/health/response/readyz.proto
@@ -10,7 +10,7 @@ option go_package = "github.com/dedyf5/resik/core/health/response";
 message HealthReadyz {
     string overall_status = 1; // @gotags: json:"overall_status" example:"UP"
     repeated HealthReadyzCheck checks = 2; // @gotags: json:"checks"
-    string accessed_at = 3; // @gotags: json:"accessed_at" example:"2025-06-14 16:42:00"
+    string accessed_at = 3; // @gotags: json:"accessed_at" example:"2026-04-17T01:30:08Z"
 }
 
 message HealthReadyzCheck {

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -20,6 +20,30 @@ type ResponseStatus struct {
 	Details any    `json:"details,omitempty"`
 }
 
+type ResponseSuccess struct {
+	Status ResponseStatusWithoutDetails `json:"status"`
+	Data   any                          `json:"data,omitempty"`
+}
+
+type ResponseSuccessWithMeta struct {
+	Status ResponseStatusWithoutDetails `json:"status"`
+	Data   any                          `json:"data,omitempty"`
+	Meta   *ResponseMeta                `json:"meta,omitempty"`
+}
+
+type ResponseErrorWithoutDetails struct {
+	Status ResponseStatusWithoutDetails `json:"status"`
+}
+
+type ResponseStatusWithoutDetails struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type ResponseBadRequest struct {
+	Status ResponseStatusBadRequest `json:"status"`
+}
+
 type ResponseStatusBadRequest struct {
 	Code    string                   `json:"code" example:"400.1"`
 	Message string                   `json:"message" example:"Bad Request"`


### PR DESCRIPTION
- Add ResponseSuccess, ResponseSuccessWithMeta, ResponseErrorWithoutDetails, and ResponseBadRequest to pkg/response for better doc generation.
- Replace fragile generic overrides in Swagger annotations.
- Standardize health check accessed_at example to use RFC3339 format.
- docs: add description for BearerAuth security definition