### PR TITLE
refactor: oneof_order validation and merchant list status codes

### DIFF
--- a/app/grpc/handler/merchant/list.go
+++ b/app/grpc/handler/merchant/list.go
@@ -34,9 +34,6 @@ func (h *MerchantHandler) MerchantListGet(c context.Context, req *reqMerchantCor
 	}
 
 	code := codes.OK
-	if len(res.Data) == 0 {
-		code = codes.NotFound
-	}
 
 	return &MerchantListGetRes{
 		Status: &status.Status{

--- a/app/rest/docs/rest_docs.go
+++ b/app/rest/docs/rest_docs.go
@@ -316,12 +316,6 @@ const docTemplaterest = `{
                             "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
-                        }
-                    },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {

--- a/app/rest/docs/rest_swagger.json
+++ b/app/rest/docs/rest_swagger.json
@@ -305,12 +305,6 @@
                             "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
                         }
                     },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/response.ResponseErrorWithoutDetails"
-                        }
-                    },
                     "429": {
                         "description": "Too Many Requests",
                         "schema": {

--- a/app/rest/docs/rest_swagger.yaml
+++ b/app/rest/docs/rest_swagger.yaml
@@ -533,10 +533,6 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/response.ResponseErrorWithoutDetails'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/response.ResponseErrorWithoutDetails'
         "429":
           description: Too Many Requests
           schema:

--- a/app/rest/handler/merchant/handler.go
+++ b/app/rest/handler/merchant/handler.go
@@ -201,7 +201,6 @@ func (h *Handler) MerchantDetailGet(echoCtx echo.Context) error {
 // @Success		200	{object}	resPkg.ResponseSuccessWithMeta{data=[]resMerchantCore.MerchantList}
 // @Failure     400 {object}	resPkg.ResponseBadRequest
 // @Failure     401 {object}	resPkg.ResponseErrorWithoutDetails
-// @Failure     404 {object}	resPkg.ResponseErrorWithoutDetails
 // @Failure     429 {object}	resPkg.ResponseErrorWithoutDetails
 // @Failure     500 {object}	resPkg.ResponseErrorWithoutDetails
 // @Router		/merchant [get]
@@ -225,13 +224,8 @@ func (h *Handler) MerchantListGet(echoCtx echo.Context) error {
 		return err
 	}
 
-	code := http.StatusOK
-	if len(res.Data) == 0 {
-		code = http.StatusNotFound
-	}
-
 	return resPkg.NewStatusDataMeta(
-		code,
+		http.StatusOK,
 		resMerchantCore.MerchantListFromEntity(res.Data),
 		&resPkg.Meta{
 			PageCurrent: param.Filter.Raw().PageOrDefault(),

--- a/utils/validator/validator.go
+++ b/utils/validator/validator.go
@@ -162,15 +162,8 @@ func registerOneOfOrder(v *validator.Validate, trans ut.Translator, msg string) 
 	return v.RegisterTranslation("oneof_order", trans, func(ut ut.Translator) error {
 		return ut.Add("oneof_order", msg, true)
 	}, func(ut ut.Translator, fe validator.FieldError) string {
-		s := strings.ReplaceAll(fe.Param(), "'", "")
-		s = strings.ReplaceAll(s, `\"`, ``)
-		base := strings.Split(s, " ")
-		vals := make([]string, 0, len(base)*2)
-		for _, v := range base {
-			vals = append(vals, v)
-			vals = append(vals, "-"+v)
-		}
-		param := strings.Join(vals, " ")
+		options := getOneOfOrderOptions(fe.Param())
+		param := strings.Join(options, " ")
 
 		t, _ := ut.T("oneof_order", fe.Field(), param)
 		return t
@@ -257,23 +250,27 @@ func (v *Validate) Translator(lang language.Tag) ut.Translator {
 }
 
 func isOneOfOrder(fl validator.FieldLevel) bool {
-	s := strings.ReplaceAll(fl.Param(), "'", "")
-	s = strings.ReplaceAll(s, "\"", "")
+	options := getOneOfOrderOptions(fl.Param())
+	fields := strings.SplitSeq(fl.Field().String(), ",")
+	for field := range fields {
+		if !slices.Contains(options, field) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func getOneOfOrderOptions(param string) []string {
+	s := strings.ReplaceAll(param, "'", "")
+	s = strings.ReplaceAll(s, `\"`, ``)
 	base := strings.Split(s, " ")
 	vals := make([]string, 0, len(base)*2)
 	for _, v := range base {
 		vals = append(vals, v)
 		vals = append(vals, "-"+v)
 	}
-
-	fields := strings.SplitSeq(fl.Field().String(), ",")
-	for field := range fields {
-		if !slices.Contains(vals, field) {
-			return false
-		}
-	}
-
-	return true
+	return vals
 }
 
 func errorReason(err validator.FieldError) string {


### PR DESCRIPTION
refactor: introduce getOneOfOrderOptions helper in validator
Centralize redundant string manipulation in oneof_order validation into a single helper function.

refactor: return success status OK for empty merchant list
Change response status from Not Found to OK in both gRPC and REST when no merchants are found to maintain consistency with list filtering standards.