### PR TITLE
refactor: update reflect usage to modern Go standards

### DIFF
--- a/app/rest/fw/echo/binder.go
+++ b/app/rest/fw/echo/binder.go
@@ -84,7 +84,7 @@ func (b *bind) ParamValidator(c echo.Context, i any) error {
 	}
 
 	df := reflect.TypeOf(i)
-	if df.Kind() == reflect.Ptr {
+	if df.Kind() == reflect.Pointer {
 		df = df.Elem()
 	}
 
@@ -93,8 +93,7 @@ func (b *bind) ParamValidator(c echo.Context, i any) error {
 	}
 
 	validate := func(tn string, getter func(string) string) error {
-		for i := 0; i < df.NumField(); i++ {
-			f := df.Field(i)
+		for f := range df.Fields() {
 			ftq := f.Tag.Get(tn)
 			if ftq == "" {
 				continue
@@ -111,9 +110,9 @@ func (b *bind) ParamValidator(c echo.Context, i any) error {
 				continue
 			}
 
-			ft := df.Field(i).Type.Kind()
-			if ft == reflect.Ptr {
-				ft = df.Field(i).Type.Elem().Kind()
+			ft := f.Type.Kind()
+			if ft == reflect.Pointer {
+				ft = f.Type.Elem().Kind()
 			}
 
 			if ft == reflect.String {

--- a/entities/common/request.go
+++ b/entities/common/request.go
@@ -10,8 +10,7 @@ type Request struct {
 }
 
 func (r *Request) LangAvailable() []string {
-	typ := reflect.TypeOf(*r)
-	fld := typ.Field(0)
+	fld := reflect.TypeFor[Request]().Field(0)
 	validate := fld.Tag.Get("validate")
 	validateList := strings.Split(validate, ",")
 	str := ""


### PR DESCRIPTION
- Replace reflect.Ptr with reflect.Pointer.
- Use reflect.TypeFor instead of reflect.TypeOf for static types.
- Simplify struct field iteration using range df.Fields().