### PR TITLE
refactor: standardize gRPC start and lazy initialization

### DIFF
--- a/app/grpc/bootstrap/app.go
+++ b/app/grpc/bootstrap/app.go
@@ -26,7 +26,9 @@ func newApp(serverHTTP *ServerHTTP) (*App, func(), error) {
 func (app *App) Start(c context.Context) {
 	runtime.GOMAXPROCS(runtime.NumCPU())
 
-	app.serverHTTP.Start()
+	if err := app.serverHTTP.Start(c); err != nil {
+		log.Fatalf("FAILED TO START HTTP SERVER: %v", err)
+	}
 
 	<-c.Done()
 

--- a/app/grpc/bootstrap/server.go
+++ b/app/grpc/bootstrap/server.go
@@ -26,26 +26,26 @@ type ServerHTTP struct {
 	interceptor *middleware.Interceptor
 }
 
-func newServerHTTP(c context.Context, config config.Config, router *Router, interceptor *middleware.Interceptor) *ServerHTTP {
-	lc := net.ListenConfig{}
-	listener, err := lc.Listen(c, "tcp", fmt.Sprintf(":%d", config.Module.Port))
-	if err != nil {
-		log.Fatalf("HTTP SERVER LISTEN ERROR: %s", err.Error())
-		return nil
-	}
-	server := grpc.NewServer(
-		grpc.ChainUnaryInterceptor(interceptor.Unary, interceptor.RateLimit),
-	)
+func newServerHTTP(config config.Config, router *Router, interceptor *middleware.Interceptor) *ServerHTTP {
 	return &ServerHTTP{
 		config:      config,
-		listener:    listener,
-		grpcServer:  server,
 		router:      router,
 		interceptor: interceptor,
 	}
 }
 
-func (s *ServerHTTP) Start() {
+func (s *ServerHTTP) Start(c context.Context) error {
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(c, "tcp", fmt.Sprintf(":%d", s.config.Module.Port))
+	if err != nil {
+		return fmt.Errorf("HTTP SERVER LISTEN ERROR: %w", err)
+	}
+	s.listener = listener
+
+	s.grpcServer = grpc.NewServer(
+		grpc.ChainUnaryInterceptor(s.interceptor.Unary, s.interceptor.RateLimit),
+	)
+
 	appName := color.Format(color.GREEN, s.config.App.Name())
 	appVersion := color.Format(color.YELLOW, s.config.App.Version())
 
@@ -67,6 +67,8 @@ func (s *ServerHTTP) Start() {
 			}
 		}
 	}()
+
+	return nil
 }
 
 func (s *ServerHTTP) Close() {

--- a/app/grpc/bootstrap/wire_gen.go
+++ b/app/grpc/bootstrap/wire_gen.go
@@ -94,7 +94,7 @@ func InitializeHTTP(c context.Context) (*App, func(), error) {
 		return nil, nil, err
 	}
 	interceptor := middleware.NewInterceptor(module, auth, limiter, logLog)
-	serverHTTP := newServerHTTP(c, config, router, interceptor)
+	serverHTTP := newServerHTTP(config, router, interceptor)
 	bootstrapApp, cleanup4, err := newApp(serverHTTP)
 	if err != nil {
 		cleanup3()


### PR DESCRIPTION
Refactors ServerHTTP to initialize the listener only when Start(c) is called. This allows for better control over the server lifecycle and improves error propagation up to the main application.