### PR TITLE
fix: update table names in down migration to plural

### DIFF
--- a/cmd/migrator/migrations/2_data_init.down.sql
+++ b/cmd/migrator/migrations/2_data_init.down.sql
@@ -3,9 +3,9 @@
 
 SET FOREIGN_KEY_CHECKS = 0;
 
-TRUNCATE TABLE `transaction`;
-TRUNCATE TABLE `outlet`;
-TRUNCATE TABLE `merchant`;
-TRUNCATE TABLE `user`;
+TRUNCATE TABLE `transactions`;
+TRUNCATE TABLE `outlets`;
+TRUNCATE TABLE `merchants`;
+TRUNCATE TABLE `users`;
 
 SET FOREIGN_KEY_CHECKS = 1;


### PR DESCRIPTION
Fix missing table name updates in 2_data_init.down.sql to match the previous refactor from singular to plural.